### PR TITLE
convert crit chance > 100 to crit damage

### DIFF
--- a/app/core/pokemon-entity.js
+++ b/app/core/pokemon-entity.js
@@ -110,6 +110,19 @@ class PokemonEntity extends schema.Schema {
       this.mana = Math.min(mana, this.maxMana);
     }
   }
+
+  addCritChance(value)
+  {
+    // for every 5% crit chance > 100, +0.1 crit damage
+    this.critChance += value
+
+    if(this.critChance > 100)
+    {
+      this.critDamage += Math.round((this.critChance - 100) * 10) / 500
+      this.critChance = 100
+    }
+
+  }
 }
 
 schema.defineTypes(PokemonEntity, {

--- a/app/core/simulation.js
+++ b/app/core/simulation.js
@@ -221,7 +221,7 @@ class Simulation extends Schema {
     }
 
     if (pokemon.items.count(ITEMS.SCOPE_LENS) != 0) {
-      pokemon.critChance += 50 * pokemon.items.count(ITEMS.SCOPE_LENS);
+      pokemon.addCritChance(50 * pokemon.items.count(ITEMS.SCOPE_LENS))
     }
 
     if (pokemon.items.count(ITEMS.RAZOR_FANG)) {
@@ -443,7 +443,7 @@ class Simulation extends Schema {
 
         case EFFECTS.ANCIENT_POWER:
           if (types.includes(TYPE.FOSSIL)) {
-            pokemon.critChance += 40;
+            pokemon.addCritChance(40)
             pokemon.critDamage += 0.8;
             pokemon.effects.push(EFFECTS.ANCIENT_POWER);
           }
@@ -451,7 +451,7 @@ class Simulation extends Schema {
 
         case EFFECTS.ELDER_POWER:
           if (types.includes(TYPE.FOSSIL)) {
-            pokemon.critChance += 70;
+            pokemon.addCritChance(70)
             pokemon.critDamage += 1.4;
             pokemon.effects.push(EFFECTS.ELDER_POWER);
           }
@@ -459,7 +459,7 @@ class Simulation extends Schema {
 
         case EFFECTS.UNOWN_GATHERINGS:
           if (types.includes(TYPE.FOSSIL)) {
-            pokemon.critChance += 100;
+            pokemon.addCritChance(100)
             pokemon.critDamage += 2.5;
             pokemon.effects.push(EFFECTS.UNOWN_GATHERINGS);
           }


### PR DESCRIPTION
extra crit damage is converted at a rate of:

for every 5 crit chance > 100, +0.1 crit damage

use pokemon.addCritChance(value) whenever adding crit chance - plan to create a general function to change a pokemon's stats instead of directly changing the variable