### PR TITLE
a quick fix to the shop to not move when you buy pokemon

### DIFF
--- a/app/public/src/pages/component/game-pokemon-portrait.jsx
+++ b/app/public/src/pages/component/game-pokemon-portrait.jsx
@@ -15,6 +15,13 @@ const COLOR_TYPE = Object.freeze({
 class GamePokemonPortrait extends Component{
 
     render(){
+        if(!this.props.name){
+            return <div style={{
+                width:'15.5%',
+                marginRight:'1%'
+            }}/>
+        }
+
         const pkm = PokemonFactory.createPokemonFromName(this.props.name);
         //console.log(pkm.rarity);
         const rarityColor = COLOR_TYPE[pkm.rarity];

--- a/app/public/src/pages/component/game-store.jsx
+++ b/app/public/src/pages/component/game-store.jsx
@@ -21,7 +21,7 @@ class GameStore extends Component{
                     return <GamePokemonPortrait key={index} name={pokemon} shopClick={this.props.shopClick} index={index}/>
                 }
                 else{
-                    return null;
+                    return <GamePokemonPortrait/>;
                 }
             })}
         </ul>;


### PR DESCRIPTION
 in game-store, instead of returning null on a bought index, return an empty game pokemon portrait