### PR TITLE
streaks are kept correctly through pve rounds

### DIFF
--- a/app/models/colyseus-models/battle-result.js
+++ b/app/models/colyseus-models/battle-result.js
@@ -2,12 +2,13 @@ const schema = require('@colyseus/schema');
 const Schema = schema.Schema;
 
 class BattleResult extends Schema {
-  constructor(name, result, avatar) {
+  constructor(name, result, avatar, isPVE=false) {
     super();
     this.assign({
       name: name,
       result: result,
-      avatar: avatar
+      avatar: avatar,
+      isPVE: isPVE 
     });
   }
 }
@@ -15,7 +16,8 @@ class BattleResult extends Schema {
 schema.defineTypes(BattleResult, {
   name: 'string',
   result: 'string',
-  avatar: 'string'
+  avatar: 'string',
+  isPVE: 'boolean'
 });
 
 module.exports = BattleResult;

--- a/app/models/colyseus-models/player.js
+++ b/app/models/colyseus-models/player.js
@@ -9,6 +9,7 @@ const BattleResult = require('./battle-result');
 const Schema = schema.Schema;
 const MapSchema = schema.MapSchema;
 const ArraySchema = schema.ArraySchema;
+const { BATTLE_RESULT } = require('../enum');
 
 class Player extends Schema {
   constructor(id, name, elo, avatar, isBot, rank, tileset) {
@@ -44,11 +45,21 @@ class Player extends Schema {
     });
   }
 
-  addBattleResult(name, result, avatar) {
+  getCurrentBattleResult(){
+    if(this.simulation.blueTeam.size == 0){
+      return BATTLE_RESULT.DEFEAT
+    }
+    else if(this.simulation.redTeam.size == 0){
+      return BATTLE_RESULT.WIN
+    }
+    return BATTLE_RESULT.DRAW
+  }
+
+  addBattleResult(name, result, avatar, isPVE) {
     if (this.history.length >= 5) {
       this.history.shift();
     }
-    this.history.push(new BattleResult(name, result, avatar));
+    this.history.push(new BattleResult(name, result, avatar, isPVE));
   }
 
   getLastBattleResult() {
@@ -57,6 +68,18 @@ class Player extends Schema {
     } else {
       return '';
     }
+  }
+
+  getLastPlayerBattleResult() {
+
+
+    for(let i = this.history.length - 1; i >= 0; i--){
+      if(!this.history[i].isPVE){
+        return this.history[i].result
+      }
+    }
+
+    return ''
   }
 
   getPokemonAt(x, y) {

--- a/app/public/src/pages/component/game-store.jsx
+++ b/app/public/src/pages/component/game-store.jsx
@@ -21,7 +21,7 @@ class GameStore extends Component{
                     return <GamePokemonPortrait key={index} name={pokemon} shopClick={this.props.shopClick} index={index}/>
                 }
                 else{
-                    return <GamePokemonPortrait/>;
+                    return <GamePokemonPortrait key={index}/>;
                 }
             })}
         </ul>;


### PR DESCRIPTION
if you lose streak into a PVE round, winning the PVE round would "convert" the streak to a win streak, since streaks were computed based on the past round's result.

created new function getLastPlayerBattleResult when looking back at history to skip PVE rounds and maintain streak type

refactoring changes
small warning fix on key value of store portrait