### PR TITLE
new ui and backend for adding/removing bots in prep room

### DIFF
--- a/app/public/src/pages/component/chat.jsx
+++ b/app/public/src/pages/component/chat.jsx
@@ -16,8 +16,7 @@ export default class Chat extends React.Component {
       backgroundColor: 'rgba(255, 255, 255, .6)',
       margin:'10px',
       height:'90vh',
-      flexBasis: '35%',
-      width: '35%'
+      flexBasis: '40%'
       }}>
         <ChatHistory 
           messages={this.props.messages}

--- a/app/public/src/pages/component/elo.jsx
+++ b/app/public/src/pages/component/elo.jsx
@@ -4,7 +4,7 @@ import {RANK} from '../../../../models/enum';
 const style = {
     display:'flex',
     alignItems:'center',
-    width:'112px'
+    width:'auto'
 }
 
 const imgStyle={
@@ -19,7 +19,9 @@ class Elo extends Component{
         let rank = this.getRank();
         return <div style={style}>
             <img style={imgStyle} src={'assets/ranks/'+ rank + '.png'}/>
-            <p>{this.props.elo}</p>
+            <div style={{marginLeft:'10px'}}>
+                <p style={{margin:'0px'}}>{this.props.elo}</p>
+            </div>
         </div>;
     }
 

--- a/app/public/src/pages/component/inline-avatar.jsx
+++ b/app/public/src/pages/component/inline-avatar.jsx
@@ -3,10 +3,10 @@ import React, { Component } from 'react';
 class InlineAvatar extends Component{
     render(){
         return <div style={{
-            display:'flex'
+            display:'flex', alignItems:'center'
             }}>
             <img style={{width:'40px', height:'40px'}} src={"/assets/avatar/" + this.props.avatar + ".png"}/>
-            <p>{this.props.name}</p>
+            <p style={{margin:'0px', marginLeft:'10px', maxWidth:'350px', overflow:'hidden', whiteSpace:'nowrap'}}>{this.props.name}</p>
         </div>;
     }
 }

--- a/app/public/src/pages/component/leaderboard-info.jsx
+++ b/app/public/src/pages/component/leaderboard-info.jsx
@@ -15,7 +15,7 @@ class LeaderboardInfo extends Component{
             <td>
                 <img src={"assets/avatar/" + this.props.avatar + ".png"}/>    
             </td>
-            <td>
+            <td style={{overflow:'hidden', whiteSpace:'nowrap', maxWidth:'300px'}}>
                 {this.props.name}
             </td>
             <td> 

--- a/app/public/src/pages/component/preparation-menu-user.jsx
+++ b/app/public/src/pages/component/preparation-menu-user.jsx
@@ -1,0 +1,36 @@
+import React, { Component } from 'react';
+import Elo from './elo';
+import InlineAvatar from './inline-avatar';
+
+class PreparationMenuUser extends Component{
+    
+
+    render(){
+        const buttonStyle = {
+            marginLeft:'10px',
+            marginRight:'10px'
+        };
+
+        const readyColor = this.props.data.ready ? "rgba(71, 138, 65, 0.4)" : "rgba(104, 109, 125, 0.4)";
+
+        const removeButton = this.props.data.isBot ? 
+            <button style={buttonStyle} className='nes-btn is-error' onClick={() => this.props.removeBot(this.props.data.id)}>Remove</button> :
+            null
+
+        return <>
+            <div className='nes-container' style={{display:'flex', padding:'10px', margin:'5px', backgroundColor:readyColor, justifyContent:'space-between'}}>
+                <div style={{display:'flex'}}>
+                    <div style={{width:'140px'}}>
+                        <Elo elo={this.props.data.elo} style={{width:'140px'}}/>
+                    </div>
+                    <InlineAvatar avatar={this.props.data.avatar} name={this.props.data.name}/>
+                </div>
+                {removeButton}
+            </div>
+        </>
+        
+    }
+
+}
+
+export default PreparationMenuUser;

--- a/app/public/src/pages/component/preparation-menu.jsx
+++ b/app/public/src/pages/component/preparation-menu.jsx
@@ -2,63 +2,105 @@ import React, { Component } from 'react';
 import Elo from './elo';
 import InlineAvatar from './inline-avatar';
 import ReactTooltip from 'react-tooltip';
+import PreparationMenuUser from './preparation-menu-user';
 
 class PreparationMenu extends Component{
+    constructor(props){
+        super(props);
+
+        this.state = {
+            botDifficulty: 'normal'
+        };
+    }
+
     render(){
         const buttonStyle = {
             marginLeft:'10px',
             marginRight:'10px'
         };
 
+        const userList = Array.from(this.props.users).map((keyPair) => {
+            return <PreparationMenuUser 
+                key={keyPair[0]} 
+                removeBot={this.props.removeBot}
+                data={keyPair[1]}
+            />
+        })
+
         return <div className="nes-container with-title is-centered" style={{
             backgroundColor: 'rgba(255, 255, 255, .6)',
              margin:'10px',
              display: 'flex',
              flexFlow: 'column',
-             justifyContent: 'space-between'
+             justifyContent: 'space-between',
+             flexBasis:'50%'
              }}>
                 <p className="title">Room id: {this.props.id}</p>
                 <div>
-                    {Array.from(this.props.users).map(this.createUser.bind(this))}
+                    {userList}
                 </div>
 
-                <div style={{display: 'flex'}}>
-                    <button style={buttonStyle} className='nes-btn is-warning' onClick={this.props.toggleReady}>Ready</button>
-                    <button 
-                        style={buttonStyle} 
-                        className={this.props.ownerId == this.props.uid ? 'nes-btn is-success':'nes-btn is-disabled'} 
-                        onClick={this.props.ownerId == this.props.uid ? this.props.startGame: null}
-                        data-tip
-                        data-for={'start-game'}
-                        >
-                        Start Game
-                        <ReactTooltip id={'start-game'} 
-                            className='customeTheme' 
-                            textColor='#000000' 
-                            backgroundColor='rgba(255,255,255,1) !important' 
-                            effect='solid'
-                            place='top'>
-                            <p>Owner: ({this.props.ownerName})</p>
-                        </ReactTooltip>
-                    </button>
-                    <button style={buttonStyle} className='nes-btn is-primary' onClick={this.props.addBot}>Add Bot</button>
-                    <button style={buttonStyle} className='nes-btn is-primary' onClick={this.props.removeBot}>Remove Bot</button>
+
+                <div style={{display: 'flex', justifyContent: 'space-between'}}>
+                    <div style={{display: 'flex'}}>
+                        <button data-tip data-for={'difficulty-select'} style={buttonStyle} className='nes-btn is-primary' onClick={() => this.props.addBot(this.state.botDifficulty)}>
+                            <ReactTooltip id={'difficulty-select'} 
+                                className='customeTheme' 
+                                textColor='#000000' 
+                                backgroundColor='rgba(255,255,255,1) !important' 
+                                effect='solid'
+                                place='top'>
+                                <p>Easy: &lt;800</p>
+                                <p>Normal: 800-1100</p>
+                                <p>Hard: &gt;1100</p>
+                            </ReactTooltip>
+                            Add Bot
+                        </button>
+
+                        <div className="nes-select" style={{width: 'auto'}} onChange={this.handleDifficultyChange.bind(this)}>
+                            
+                            <select defaultValue={this.state.botDifficulty}>
+                                <option value="easy">Easy</option>
+                                <option value="normal">Normal</option>
+                                <option value="hard">Hard</option>
+                            </select>
+                        </div>
+                        
+                    </div>
+                    <div>
+                        <button style={buttonStyle} className='nes-btn is-warning' onClick={this.props.toggleReady}>Ready</button>
+                        <button 
+                            style={buttonStyle} 
+                            className={this.props.ownerId == this.props.uid ? 'nes-btn is-success':'nes-btn is-disabled'} 
+                            onClick={this.props.ownerId == this.props.uid ? this.props.startGame: null}
+                            data-tip
+                            data-for={'start-game'}
+                            >
+                            Start Game
+                            <ReactTooltip id={'start-game'} 
+                                className='customeTheme' 
+                                textColor='#000000' 
+                                backgroundColor='rgba(255,255,255,1) !important' 
+                                effect='solid'
+                                place='top'>
+                                <p>Owner: ({this.props.ownerName})</p>
+                            </ReactTooltip>
+                        </button>
+                    </div>
+
+                    
                 </div>
             </div>
     }
 
-    createUser(keyValue){
-        const k = keyValue[0];
-        const v = keyValue[1];
-        const ready = v.ready ? 'V' : 'X';
-        return <div key={k} style={{display:'flex', justifyContent:'space-between'}}>
-            <div style={{display:'flex'}}>
-                <Elo elo={v.elo}/>
-                <InlineAvatar avatar={v.avatar} name={v.name}/>
-            </div>
-            <p>{ready}</p>
-        </div>
+    handleDifficultyChange(e){
+        if(e.target.value.length !=0){
+            this.setState({
+                botDifficulty: e.target.value
+            });
+        }
     }
+
 }
 
 export default PreparationMenu;

--- a/app/public/src/pages/preparation.jsx
+++ b/app/public/src/pages/preparation.jsx
@@ -113,12 +113,12 @@ class Preparation extends Component {
         this.room.send('new-message', {'name': this.state.user.name, 'payload': payload, 'avatar':this.state.user.avatar });
     }
 
-    addBot(){
-        this.room.send('addBot');
+    addBot(difficulty){
+        this.room.send('addBot', difficulty);
     }
 
-    removeBot(){
-        this.room.send('removeBot');
+    removeBot(target){
+        this.room.send('removeBot', target);
     }
 
     toggleReady(){

--- a/app/rooms/preparation-room.js
+++ b/app/rooms/preparation-room.js
@@ -10,7 +10,8 @@ const {
   OnToggleReadyCommand,
   OnMessageCommand,
   OnAddBotCommand,
-  OnRemoveBotCommand
+  OnRemoveBotCommand,
+  InitializeBotsCommand
 } = require('./commands/preparation-commands');
 
 class PreparationRoom extends colyseus.Room {
@@ -27,20 +28,7 @@ class PreparationRoom extends colyseus.Room {
     this.setState(new PreparationState(options.ownerId));
     this.maxClients = 8;
 
-    Bot.find({}, ['avatar', 'elo'], null, (err, bots) => {
-      if (bots) {
-        bots.forEach((bot) => {
-          self.elos.set(bot.avatar, bot.elo);
-        });
-        self.dispatcher.dispatch(new OnAddBotCommand());
-        self.dispatcher.dispatch(new OnAddBotCommand());
-        self.dispatcher.dispatch(new OnAddBotCommand());
-        self.dispatcher.dispatch(new OnAddBotCommand());
-        self.dispatcher.dispatch(new OnAddBotCommand());
-        self.dispatcher.dispatch(new OnAddBotCommand());
-        self.dispatcher.dispatch(new OnAddBotCommand());
-      }
-    });
+    self.dispatcher.dispatch(new InitializeBotsCommand(), options.ownerId)
 
     this.onMessage('game-start', (client, message) => {
       try {
@@ -63,16 +51,16 @@ class PreparationRoom extends colyseus.Room {
         console.log(error);
       }
     });
-    this.onMessage('addBot', (client, message) => {
+    this.onMessage('addBot', (client, difficulty) => {
       try {
-        this.dispatcher.dispatch(new OnAddBotCommand());
+        this.dispatcher.dispatch(new OnAddBotCommand(), {difficulty: difficulty});
       } catch (error) {
         console.log(error);
       }
     });
-    this.onMessage('removeBot', (client, message) => {
+    this.onMessage('removeBot', (client, target) => {
       try {
-        this.dispatcher.dispatch(new OnRemoveBotCommand());
+        this.dispatcher.dispatch(new OnRemoveBotCommand(), {target: target});
       } catch (error) {
         console.log(error);
       }


### PR DESCRIPTION
-remove button by bot profile, bot difficulty dropdown in prep lobby
-OnRemoveBotCommand can now take a message.target and will remove a bot by that name. if no target is specified, the first bot will be deleted (TODO: if all players are not bots, this may fail)
-OnAddBotCommand can now take a message.difficulty and will query the Bot database for a bot in that difficulty range
-InitializeBotsCommand is now used to fill a lobby with bots +/- 100 of the owner's elo. did not want to do 7 OnAddBotCommands because of async issues
-some ui tweaks