### PR TITLE
quick fix for item details showing when switching between players

### DIFF
--- a/app/public/src/game/components/board-manager.ts
+++ b/app/public/src/game/components/board-manager.ts
@@ -74,6 +74,10 @@ export default class BoardManager {
   }
 
   setPlayer(player: IPlayer) {
+    if(this.mode == 'battle'){
+      return
+    }
+
     if (player.id != this.player.id) {
       this.pokemons.forEach((pokemon, key) => {
         pokemon.destroy(true);


### PR DESCRIPTION
what happens is that when you switch to a player while in 'battle' mode, pokemonUI's are still created, and the item details are for some reason added as visible. did not look into too deep because i want to make a better way to handle item details - this is more of a temp fix :)