### PR TITLE
made difficulty ranges clearer

### DIFF
--- a/app/public/src/pages/component/preparation/preparation-menu.tsx
+++ b/app/public/src/pages/component/preparation/preparation-menu.tsx
@@ -85,8 +85,8 @@ export default function PreparationMenu(props:{setToGame: Dispatch<SetStateActio
                             effect='solid'
                             place='top'>
                             <p>Easy: &lt;800</p>
-                            <p>Normal: 800-1100</p>
-                            <p>Hard: &gt;1100</p>
+                            <p>Normal: 800-1099</p>
+                            <p>Hard: &gt;=1100</p>
                         </ReactTooltip>
                         Add Bot
                     </button>

--- a/app/rooms/commands/preparation-commands.ts
+++ b/app/rooms/commands/preparation-commands.ts
@@ -169,10 +169,10 @@ export class OnAddBotCommand extends Command<PreparationRoom, OnAddBotPayload> {
         d = {$lt: 800}
         break
       case BotDifficulty.MEDIUM:
-        d = {$gt: 800, $lt: 1100}
+        d = {$gte: 800, $lt: 1100}
         break
       case BotDifficulty.HARD:
-        d = {$gt: 1100}
+        d = {$gte: 1100}
         break
     }
 


### PR DESCRIPTION
easy bots: below 800
medium: 800 to 1099
hard: above 1100

fixed some greater/less equal to logic, bots at exactly 800 and 1100 could not be selected
edited text on frontend to reflect changes