### PR TITLE
change border color of pokemon portrait based on rarity level

### DIFF
--- a/app/public/src/pages/component/game/game-pokemon-portrait.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-portrait.tsx
@@ -31,6 +31,7 @@ export default function GamePokemonPortrait(props: {
           imageRendering: "pixelated",
           width: "15%",
           backgroundColor: rarityColor,
+          borderColor: rarityColor,
           backgroundImage: `url("${getPortraitSrc(
             props.pokemon.index,
             props.pokemonConfig?.selectedShiny,


### PR DESCRIPTION
Depending on the user screen aspect ratio, the rarity color of Pokemons in the shop was not visible for the player.

To fix this, I also change the border-color so that it's visible on all aspect ratios.

**On wide screens:**

Before:
![image](https://user-images.githubusercontent.com/566536/211225334-e62cdf7c-f9d5-4df7-8f78-1b619fad3266.png)

After:
![image](https://user-images.githubusercontent.com/566536/211225397-19929373-61d9-4448-863d-70cb5e0f901e.png)

**On less wide screens:**

Before:
![image](https://user-images.githubusercontent.com/566536/211225322-a6bb544f-ba86-4c0a-8d2b-f43cc1fcae5d.png)

After:
![image](https://user-images.githubusercontent.com/566536/211225382-e8742998-f664-4377-9e2f-c4702a364748.png)



