### PR TITLE
fix player 1 tooltip position

### DIFF
--- a/app/public/src/pages/component/game/game-player.tsx
+++ b/app/public/src/pages/component/game/game-player.tsx
@@ -58,7 +58,7 @@ export default function GamePlayer(props: {
         textColor="#000000"
         effect="solid"
         place="left"
-        offset={{ left: 30 }}
+        offset={{ left: 30, bottom: props.index === 0 ? 50 : 0 }}
       >
         <GamePlayerDetail
           name={props.player.name}


### PR DESCRIPTION
Add a 50px bottom offset for player 1 tooltip because it was out of screen.

I thought react-tooltip was supposed to deal with this but apparently not. Maybe something is wrong with the CSS that prevents the lib doing the right computations. I don't know well this library so I'm doing this quick fix for now.

Before:
![image](https://user-images.githubusercontent.com/566536/211388764-4e1509f3-4a14-407e-80f7-80aa3551f7ad.png)

After:
![image](https://user-images.githubusercontent.com/566536/211388780-859d30ee-efbd-4cf1-8e21-b39c67b7c1b2.png)
