### PR TITLE
redesign player titles menu

### DIFF
--- a/app/public/src/pages/component/lobby-menu/profile.tsx
+++ b/app/public/src/pages/component/lobby-menu/profile.tsx
@@ -148,25 +148,27 @@ export default function Profile() {
           </TabPanel>
           <TabPanel>
             <div className="playerBox">
-              <div style={{ display: "flex", flexWrap: "wrap" }}>
-                {Object.keys(Title).map((k) => (
-                  <div key={k}>
+              <div style={{ display: "flex", flexDirection: "column" }}>
+                {Object.keys(Title).map((k,i) => (
+                  <div key={k} style={{ 
+                    padding: "0.5em", 
+                    backgroundColor: i%2 ? '#54596b' : '#61738a'
+                  }}>
                     <h5
                       onClick={() => {
                         if (user.titles.includes(k as Title)) {
                           dispatch(setTitle(k))
                         }
                       }}
-                      style={{
-                        color: user.titles.includes(k as Title)
-                          ? "#28a745"
-                          : "#db5e6a"
-                      }}
+                      style={{ color: user.title === k ? '#ffc107' : user.titles.includes(k as Title) ? "#92cc41" : "#db5e6a" }}
                       className="my-cursor"
                     >
                       {TitleName[k]}
                     </h5>
-                    <p>{TitleDescription[k]}</p>
+                    <p style={{ 
+                      margin: 0, 
+                      color: user.titles.includes(k as Title) ? '#ffffff' : '#a0a0a0'
+                    }}>{TitleDescription[k]}</p>
                   </div>
                 ))}
               </div>


### PR DESCRIPTION
I had some issues with the player titles tab on wide screens, so I redesigned it:

Before:
![image](https://user-images.githubusercontent.com/566536/211404765-8e27866c-bdfc-401e-b945-9451d5e8ce32.png)

After:
![image](https://user-images.githubusercontent.com/566536/211404814-c0c48167-5207-43de-808b-25097f09e6ab.png)

Selected title is in gold color, other unlocked titles are in green.
