### PR TITLE
added synergy-icon component

### DIFF
--- a/app/public/src/game/components/pokemon-detail.ts
+++ b/app/public/src/game/components/pokemon-detail.ts
@@ -104,6 +104,7 @@ export default class PokemonDetail extends GameObjects.DOMElement {
     types.forEach((type) => {
       const ty = document.createElement("img")
       ty.src = "assets/types/" + type + ".png"
+      ty.className = "synergy-icon"
       ty.style.width = "34px"
       ty.style.height = "34px"
       t.appendChild(ty)

--- a/app/public/src/pages/component/bot-builder/pokemon-picker.tsx
+++ b/app/public/src/pages/component/bot-builder/pokemon-picker.tsx
@@ -6,6 +6,8 @@ import PRECOMPUTED_TYPE_POKEMONS_ALL from "../../../../../models/precomputed/typ
 import { Item } from "../../../../../types/enum/Item"
 import { getPortraitSrc } from "../../../utils"
 import { DetailledPkm, Emotion } from "../../../../../types"
+import SynergyIcon from "../icons/synergy-icon"
+import { Synergy } from "../../../../../types/enum/Synergy"
 
 const pokemonPoolStyle: CSS.Properties = {
   display: "flex",
@@ -36,7 +38,7 @@ export default function PokemonPicker(props: {
         {Object.keys(PRECOMPUTED_TYPE_POKEMONS_ALL).map((t) => {
           return (
             <Tab style={cursorStyle} key={t}>
-              <img src={"assets/types/" + t + ".png"}></img>
+              <SynergyIcon type={t as Synergy} />
             </Tab>
           )
         })}

--- a/app/public/src/pages/component/bot-builder/selected-entity.tsx
+++ b/app/public/src/pages/component/bot-builder/selected-entity.tsx
@@ -13,6 +13,7 @@ import {
   AbilityName,
   AbilityDescription,
 } from "../../../../../types/strings/Ability"
+import SynergyIcon from "../icons/synergy-icon"
 
 const entityStyle: CSS.Properties = {
   position: "absolute",
@@ -132,9 +133,7 @@ export default function SelectedEntity(props: {
           <p style={{ color: RarityColor[pokemon.rarity] }}>{pokemon.rarity}</p>
           <div>
             {pokemon.types.map((type) => {
-              return (
-                <img key={"img" + type} src={"assets/types/" + type + ".png"} />
-              )
+              return (<SynergyIcon type={type} key={"img" + type} />)
             })}
           </div>
           <p>Health: {pokemon.hp}</p>

--- a/app/public/src/pages/component/collection/pokemon-collection.tsx
+++ b/app/public/src/pages/component/collection/pokemon-collection.tsx
@@ -14,6 +14,7 @@ import { ITracker } from "../../../../../types/ITracker"
 import PokemonEmotion from "./pokemon-emotion"
 import { Pkm } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../utils"
+import SynergyIcon from "../icons/synergy-icon"
 
 const buttonStyle: CSS.Properties = {
   marginLeft: "10px",
@@ -180,11 +181,10 @@ export default function PokemonCollection(props: {
       <div style={{ margin: "10px" }} className="nes-container">
         <Tabs>
           <TabList>
-            {(Object.keys(Synergy) as Synergy[]).map((r) => {
+            {(Object.keys(Synergy) as Synergy[]).map((type) => {
               return (
-                <Tab key={"title-" + r}>
-                  {" "}
-                  <img src={"assets/types/" + r + ".png"}></img>
+                <Tab key={"title-" + type}>
+                  <SynergyIcon type={type} />                  
                 </Tab>
               )
             })}

--- a/app/public/src/pages/component/game/game-pokemon-detail.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-detail.tsx
@@ -6,6 +6,7 @@ import {
   AbilityDescription,
 } from "../../../../../types/strings/Ability"
 import { getPortraitSrc } from "../../../utils"
+import SynergyIcon from "../icons/synergy-icon"
 
 const pStyle = {
   margin: "0px",
@@ -36,11 +37,7 @@ export function GamePokemonDetail(props: { pokemon: Pokemon }) {
           )}
         />
         <div>
-          {props.pokemon.types.map((type) => {
-            return (
-              <img key={"img" + type} src={"assets/types/" + type + ".png"} />
-            )
-          })}
+          {props.pokemon.types.map((type) => <SynergyIcon type={type} />)}
         </div>
         <p style={{ color: RarityColor[props.pokemon.rarity] }}>
           {props.pokemon.rarity}

--- a/app/public/src/pages/component/game/game-pokemon-portrait.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-portrait.tsx
@@ -4,6 +4,7 @@ import { IPokemonConfig } from "../../../../../models/mongo-models/user-metadata
 import { PkmCost, RarityColor } from "../../../../../types/Config"
 import { getPortraitSrc } from "../../../utils"
 import { GamePokemonDetail } from "./game-pokemon-detail"
+import SynergyIcon from "../icons/synergy-icon"
 import ReactTooltip from "react-tooltip"
 
 export default function GamePokemonPortrait(props: {
@@ -98,7 +99,7 @@ export default function GamePokemonPortrait(props: {
           {props.pokemon.types.map((type) => {
             return (
               <li key={type}>
-                <img src={"assets/types/" + type + ".png"} />
+                <SynergyIcon type={type} />
               </li>
             )
           })}

--- a/app/public/src/pages/component/icons/synergy-icon.css
+++ b/app/public/src/pages/component/icons/synergy-icon.css
@@ -1,0 +1,6 @@
+.synergy-icon {
+    width: 34px;
+    height: 34px;
+    filter: drop-shadow(2px 2px 1px black);
+    margin: 4px;
+}

--- a/app/public/src/pages/component/icons/synergy-icon.tsx
+++ b/app/public/src/pages/component/icons/synergy-icon.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { Synergy } from "../../../../../types/enum/Synergy"
+import "./synergy-icon.css"
+
+export default function SynergyIcon(props: {
+    type: Synergy,
+    size?: string
+}) {
+  return (
+    <img src={"assets/types/" + props.type + ".png"} 
+         alt={props.type} 
+         className="synergy-icon"
+         style={{ width: props.size ?? '34px', height: props.size ?? '34px', imageRendering: "pixelated" }}
+    />
+  )
+}

--- a/app/public/src/pages/component/meta-report/team-comp.tsx
+++ b/app/public/src/pages/component/meta-report/team-comp.tsx
@@ -3,6 +3,7 @@ import { IMeta } from "../../../../../models/mongo-models/meta"
 import { Pkm, PkmIndex } from "../../../../../types/enum/Pokemon"
 import { Synergy } from "../../../../../types/enum/Synergy"
 import { getPortraitSrc } from "../../../utils"
+import SynergyIcon from "../icons/synergy-icon"
 
 function capitalizeFirstLetter(string: string) {
   if (string) {
@@ -71,15 +72,7 @@ export default function TeamComp(props: { team: IMeta }) {
                 }}
                 key={type}
               >
-                <img
-                  style={{
-                    width: "51px",
-                    height: "51px",
-                    imageRendering: "pixelated",
-                    marginRight: "4px"
-                  }}
-                  src={"assets/types/" + type.toUpperCase() + ".png"}
-                />
+                <SynergyIcon type={type.toUpperCase() as Synergy} size="51px" />
                 <p>{props.team.types[type]}</p>
               </div>
             )

--- a/app/public/src/pages/component/synergy/synergy-component.tsx
+++ b/app/public/src/pages/component/synergy/synergy-component.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { TypeTrigger } from "../../../../../types/Config"
 import ReactTooltip from "react-tooltip"
 import SynergyDetailComponent from "./synergy-detail-component"
+import SynergyIcon from "../icons/synergy-icon"
 import { Synergy } from "../../../../../types/enum/Synergy"
 import { SynergyName } from "../../../../../types/strings/Synergy"
 
@@ -43,13 +44,7 @@ export default function SynergyComponent(props: {
         <SynergyDetailComponent type={props.type} value={props.value} />
       </ReactTooltip>
 
-      <img
-        style={{
-          height: "40px",
-          width: "40px"
-        }}
-        src={"assets/types/" + props.type + ".png"}
-      />
+      <SynergyIcon type={props.type} size="40px" />
       <h4>{props.value}</h4>
       <div
         style={{

--- a/app/public/src/pages/component/synergy/synergy-detail-component.tsx
+++ b/app/public/src/pages/component/synergy/synergy-detail-component.tsx
@@ -15,6 +15,7 @@ import {
 import { TypeTrigger, RarityColor } from "../../../../../types/Config"
 import { useAppSelector } from "../../../hooks"
 import { getPortraitSrc } from "../../../utils"
+import SynergyIcon from "../icons/synergy-icon"
 
 const precomputed = PRECOMPUTED_TYPE_POKEMONS as PrecomputedTypePokemon
 
@@ -28,10 +29,7 @@ export default function SynergyDetailComponent(props: {
   return (
     <div>
       <div style={{ display: "flex" }}>
-        <img
-          style={{ width: "40px", height: "40px", marginRight: "1%" }}
-          src={"assets/types/" + props.type + ".png"}
-        />
+        <SynergyIcon type={props.type} size="40px" />
         <h3>{SynergyName[props.type].eng}</h3>
       </div>
 

--- a/app/public/src/pages/component/wiki/wiki-pokemon-detail.tsx
+++ b/app/public/src/pages/component/wiki/wiki-pokemon-detail.tsx
@@ -12,6 +12,7 @@ import Credits from "./Credits"
 import { RarityColor } from "../../../../../types/Config"
 import { Pkm } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../utils"
+import SynergyIcon from "../icons/synergy-icon"
 
 export default function WikiPokemonDetail(props: {
   pokemon: Pkm
@@ -49,11 +50,7 @@ export default function WikiPokemonDetail(props: {
           </p>
           <div>
             types:
-            {pokemon.types.map((type) => {
-              return (
-                <img key={"img" + type} src={"assets/types/" + type + ".png"} />
-              )
-            })}
+            {pokemon.types.map((type) => <SynergyIcon key={"img" + type} type={type} />)}
           </div>
           <div>
             evolution:{" "}

--- a/app/public/src/pages/component/wiki/wiki-type.tsx
+++ b/app/public/src/pages/component/wiki/wiki-type.tsx
@@ -12,12 +12,13 @@ import { TypeTrigger } from "../../../../../types/Config"
 import { Synergy } from "../../../../../types/enum/Synergy"
 import { Pkm, PkmIndex } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../utils"
+import SynergyIcon from "../icons/synergy-icon"
 
 export default function WikiType(props: { type: Synergy }) {
   return (
     <div>
       <div style={{ display: "flex" }}>
-        <img src={"assets/types/" + props.type + ".png"}></img>
+        <SynergyIcon type={props.type} />
         <p>{SynergyName[props.type].eng}</p>
       </div>
       {SynergyDetail[props.type].map((effect, i) => {

--- a/app/public/src/pages/component/wiki/wiki-types.tsx
+++ b/app/public/src/pages/component/wiki/wiki-types.tsx
@@ -2,17 +2,16 @@ import React from "react"
 import { Tab, Tabs, TabList, TabPanel } from "react-tabs"
 import WikiType from "./wiki-type"
 import { Synergy } from "../../../../../types/enum/Synergy"
+import SynergyIcon from "../icons/synergy-icon"
 
 export default function WikiTypes() {
   return (
     <Tabs>
       <TabList>
-        {(Object.keys(Synergy) as Synergy[]).map((r) => {
-          // console.log('synergies', r)
+        {(Object.keys(Synergy) as Synergy[]).map((type) => {
           return (
-            <Tab key={"title-" + r}>
-              {" "}
-              <img src={"assets/types/" + r + ".png"}></img>
+            <Tab key={"title-" + type}>
+              <SynergyIcon type={type} />
             </Tab>
           )
         })}


### PR DESCRIPTION
I refactored the code to add a synergy icon component, considering the number of times the img code has been duplicated in the current codebase. It should help maintaining these synergy icons style long term.

I also took this opportunity to add a small margin and drop shadow to the icons, that IMO improves the readability. What do you think ?

Before:
![image](https://user-images.githubusercontent.com/566536/211612351-4c0422ac-cb6e-4ea0-94fe-70b43316c548.png)

After:
![image](https://user-images.githubusercontent.com/566536/211612371-fe42ca89-b9ea-479f-bc3f-1806c85f43ae.png)

Before:
![image](https://user-images.githubusercontent.com/566536/211612428-131becdd-6f43-41bb-be91-8ce4663b8bc6.png)

After:
![image](https://user-images.githubusercontent.com/566536/211612409-d3a5afe3-79e7-4e17-8bc4-36ca6fa3f30a.png)
