### PR TITLE
Cache worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 node_modules/
 .vscode/
 *.env
-app/public/dist/**/*.js
-app/public/dist/**/*.js.map
+app/public/dist/server/**/*.js
+app/public/dist/server/**/*.js.map
 app/public/dist/**/*.d.ts
-app/public/dist/**/client/index.css
-app/public/dist/**/client/index.css.map
+app/public/dist/client/index.js
+app/public/dist/client/index.js.map
+app/public/dist/client/index.css
+app/public/dist/client/index.css.map
 *.code-workspace
 /app/public/dist/assets/tiles/newBackground.tmx
 /app/public/dist/assets/tiles/sleepBackground.json

--- a/app/public/dist/client/sw.js
+++ b/app/public/dist/client/sw.js
@@ -1,0 +1,43 @@
+const CACHE_NAME = 'CACHE_V1';
+
+// Cache-first strategy
+const cacheFirst = (event) => {
+    event.respondWith(
+        caches.match(event.request).then((cacheResponse) => {
+            return cacheResponse || fetch(event.request).then((networkResponse) => {
+                if(networkResponse.ok && networkResponse.status !== 206){ // do not cache errors or partial content
+                    return caches.open(CACHE_NAME).then((cache) => {
+                        cache.put(event.request, networkResponse.clone());
+                        return networkResponse
+                    })
+                }
+                return networkResponse;
+            })
+        })
+    )
+}
+
+async function clearObsoleteCaches() {
+    const cachesKeys = await caches.keys()
+    return Promise.all(
+        cachesKeys.filter(key => key !== CACHE_NAME)
+            .map(oldCache => caches.delete(oldCache))
+    )
+}
+
+self.addEventListener('fetch', async (event) => {
+    const url = event.request.url
+    if (event.request.method === 'GET' && (
+           url.includes("/assets/")
+        || url.includes("/SpriteCollab/")
+        || url.includes("/pokemonAutoChessMusic/")
+    )) cacheFirst(event)
+});
+
+self.addEventListener('install', function () {
+    self.skipWaiting(); // immediately activates this service worker
+})
+
+self.addEventListener('activate', event => {
+    event.waitUntil(clearObsoleteCaches().then(() => self.clients.claim()));
+});

--- a/app/public/dist/client/sw.js
+++ b/app/public/dist/client/sw.js
@@ -1,4 +1,6 @@
-const CACHE_NAME = 'CACHE_V1';
+/* Change this cache name every time you want to force players 
+  to invalidate their cache and download all assets again */
+const CACHE_NAME = 'CACHE v2.4.0';
 
 // Cache-first strategy
 const cacheFirst = (event) => {

--- a/app/public/src/index.tsx
+++ b/app/public/src/index.tsx
@@ -26,3 +26,7 @@ ReactDOM.render(
 
   document.getElementById("root")
 )
+
+if (navigator.serviceWorker) {
+  navigator.serviceWorker.register('sw.js')
+}

--- a/app/public/src/pages/component/game/game-pokemon-detail.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-detail.tsx
@@ -37,7 +37,7 @@ export function GamePokemonDetail(props: { pokemon: Pokemon }) {
           )}
         />
         <div>
-          {props.pokemon.types.map((type) => <SynergyIcon type={type} />)}
+          {props.pokemon.types.map((type) => <SynergyIcon type={type} key={type} />)}
         </div>
         <p style={{ color: RarityColor[props.pokemon.rarity] }}>
           {props.pokemon.rarity}


### PR DESCRIPTION
Add a service worker to cache all assets and drastically improve game loading times after downloaded once. It still takes around 15 seconds on my machine to load due to the high number of requests (~1500 requests, so around 10ms per request on average).

This should also save a lot of bandwith for the server 😅 

To invalidate cache and force users to redownload the assets, you will have to update `CACHE_NAME` variable and users will have to refresh the page once. Note: I can add an update notification or force the page refresh but I believe this is not good for the user experience, and the modifications done on assets should not be that crucial that we need to force people to update. I decided not to link this cache name to the current package version because I believe most of the future updates should not require invalidating assets cache.