### PR TITLE
redesign pokemon tooltips

### DIFF
--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -364,22 +364,22 @@ export default class BattleManager {
           } else if (change.field == "critChance") {
             pkm.critChance = pokemon.critChance
             if (pkm.detail) {
-              pkm.detail.critChance.innerHTML = pokemon.critChance.toString()
+              pkm.detail.critChance.textContent = pokemon.critChance.toString()+"%"
             }
           } else if (change.field == "critDamage") {
             pkm.critDamage = parseFloat(pokemon.critDamage.toFixed(2))
             if (pkm.detail) {
-              pkm.detail.critDamage.innerHTML = pokemon.critDamage.toFixed(2)
+              pkm.detail.critDamage.textContent = pokemon.critDamage.toFixed(2)
             }
           } else if (change.field == "spellDamage") {
             pkm.spellDamage = pokemon.spellDamage
             if (pkm.detail) {
-              pkm.detail.spellDamage.innerHTML = pokemon.spellDamage.toString()
+              pkm.detail.spellDamage.textContent = pokemon.spellDamage.toString()
             }
           } else if (change.field == "atkSpeed") {
             pkm.atkSpeed = pokemon.atkSpeed
             if (pkm.detail) {
-              pkm.detail.atkSpeed.innerHTML = pokemon.atkSpeed.toFixed(2)
+              pkm.detail.atkSpeed.textContent = pokemon.atkSpeed.toFixed(2)
             }
           } else if (change.field == "life") {
             if (change.value && change.previousValue) {
@@ -392,7 +392,7 @@ export default class BattleManager {
             pkm.life = pokemon.life
             pkm.lifebar?.setAmount(pkm.life)
             if (pkm.detail) {
-              pkm.detail.hp.innerHTML = pokemon.life.toString()
+              pkm.detail.hp.textContent = pokemon.life.toString()
             }
           } else if (change.field == "shield") {
             if (change.value && change.previousValue) {

--- a/app/public/src/game/components/pokemon-detail.ts
+++ b/app/public/src/game/components/pokemon-detail.ts
@@ -1,5 +1,5 @@
 import { GameObjects } from "phaser"
-import { AttackType } from "../../../../types/enum/Game"
+import { AttackType, Rarity } from "../../../../types/enum/Game"
 import { Emotion } from "../../../../types"
 import {
   AbilityName,
@@ -7,6 +7,8 @@ import {
 } from "../../../../types/strings/Ability"
 import { Ability } from "../../../../types/enum/Ability"
 import { getPortraitSrc } from "../../utils"
+import { AttackTypeColor, RarityColor } from "../../../../types/Config"
+import { AttackTypeLabel } from "../../../../types/strings/AttackType"
 
 export default class PokemonDetail extends GameObjects.DOMElement {
   dom: HTMLDivElement
@@ -26,6 +28,7 @@ export default class PokemonDetail extends GameObjects.DOMElement {
     x: number,
     y: number,
     name: string,
+    rarity: Rarity,
     hp: number,
     atk: number,
     def: number,
@@ -47,264 +50,124 @@ export default class PokemonDetail extends GameObjects.DOMElement {
 
     this.dom = document.createElement("div")
     this.dom.className = "nes-container"
-    this.dom.style.color = "#fff"
-    this.dom.style.padding = "10px"
-
     const wrap = document.createElement("div")
-    wrap.style.display = "flex"
-
-    const infos = document.createElement("div")
-    infos.style.display = "flex"
-    infos.style.flexFlow = "column"
-    infos.style.minWidth = "200px"
+    wrap.className = "game-pokemon-detail"
 
     this.hp = document.createElement("p")
-    this.hp.innerHTML = hp.toString()
+    this.hp.textContent = hp.toString()
 
     this.atk = document.createElement("p")
-    this.atk.innerHTML = atk.toString()
+    this.atk.textContent = atk.toString()
 
     this.def = document.createElement("p")
-    this.def.innerHTML = def.toString()
+    this.def.textContent = def.toString()
 
     this.speDef = document.createElement("p")
-    this.speDef.innerHTML = speDef.toString()
+    this.speDef.textContent = speDef.toString()
 
     this.range = document.createElement("p")
-    this.range.innerHTML = range.toString()
+    this.range.textContent = range.toString()
 
     this.atkSpeed = document.createElement("p")
-    this.atkSpeed.innerHTML = atkSpeed.toString()
+    this.atkSpeed.textContent = atkSpeed.toString()
 
     this.critChance = document.createElement("p")
-    this.critChance.innerHTML = critChance.toString()
+    this.critChance.textContent = critChance.toString() + "%"
 
     this.critDamage = document.createElement("p")
-    this.critDamage.innerHTML = critDamage.toString()
+    this.critDamage.textContent = critDamage.toString()
 
     this.spellDamage = document.createElement("p")
-    this.spellDamage.innerHTML = spellDamage.toString()
+    this.spellDamage.textContent = spellDamage.toString()
 
     this.mana = document.createElement("p")
     this.mana.innerHTML = mana.toString()
 
-    const pokemonName = document.createElement("p")
-    pokemonName.innerHTML = capitalizeFirstLetter(name)
-
     const avatar = document.createElement("img")
+    avatar.className = "game-pokemon-detail-portrait"
     avatar.src = getPortraitSrc(index, shiny, emotion)
+    avatar.style.borderColor = RarityColor[rarity]
+    wrap.appendChild(avatar)
 
-    const profile = document.createElement("div")
-    profile.style.display = "flex"
-    profile.style.alignItems = "center"
-    profile.style.justifyContent = "space-around"
+    const entry = document.createElement("div")
+    entry.className = "game-pokemon-detail-entry"
+    wrap.appendChild(entry)
 
-    const t = document.createElement("div")
-    t.style.display = "flex"
+    const pokemonName = document.createElement("p")
+    pokemonName.textContent = name
+    pokemonName.className = "game-pokemon-detail-entry-name"
+    entry.appendChild(pokemonName)
+
+    const pokemonRarity = document.createElement("p")
+    pokemonRarity.textContent = rarity
+    pokemonRarity.style.color = RarityColor[rarity]
+    pokemonRarity.className = "game-pokemon-detail-entry-rarity"
+    entry.appendChild(pokemonRarity)
+
+    const attackTypeElm = document.createElement("p")
+    attackTypeElm.textContent = AttackTypeLabel[attackType].eng
+    attackTypeElm.style.color = AttackTypeColor[attackType]
+    attackTypeElm.className = "game-pokemon-detail-entry-attack-type"
+    entry.appendChild(attackTypeElm)
+
+    const typesList = document.createElement("div")
+    typesList.className = "game-pokemon-detail-types"
     types.forEach((type) => {
       const ty = document.createElement("img")
       ty.src = "assets/types/" + type + ".png"
+      ty.alt = type;
+      ty.title = type;
       ty.className = "synergy-icon"
       ty.style.width = "34px"
       ty.style.height = "34px"
-      t.appendChild(ty)
+      typesList.appendChild(ty)
     })
+    wrap.appendChild(typesList)
 
-    const a = document.createElement("p")
-    switch (attackType) {
-      case AttackType.PHYSICAL:
-        a.innerHTML = "Physical"
-        a.className = "nes-text is-error"
-        break
-      case AttackType.SPECIAL:
-        a.innerHTML = "Special"
-        a.className = "nes-text is-primary"
-        break
-      case AttackType.TRUE:
-        a.innerHTML = "True"
-        a.className = "nes-text is-success"
-        break
-      default:
-        break
+    const stats = [
+      { title: "Health points", img: "assets/icons/hp.png", value: this.hp },
+      { title: "Defense", img: "assets/icons/def.png", value: this.def },
+      { title: "Attack", img: "assets/icons/atk.png", value: this.atk },
+      { title: "Attack Speed", img: "assets/icons/atkSpeed.png", value: this.atkSpeed },
+      { title: "Critical Damage", img: "assets/icons/critDamage.png", value: this.critDamage },
+      { title: "Mana", img: "assets/icons/mana.png", value: this.mana },
+      { title: "Special Defense", img: "assets/icons/speDef.png", value: this.speDef },
+      { title: "Spell Damage", img: "assets/icons/spellDamage.png", value: this.spellDamage },
+      { title: "Attack Range", img: "assets/icons/range.png", value: this.range },
+      { title: "Critical Chance", img: "assets/icons/critChance.png", value: this.critChance },
+    ]
+
+    const statsElm = document.createElement("div")
+    statsElm.className = "game-pokemon-detail-stats"
+    for(let stat of stats){
+      const statElm = document.createElement("div")
+      const statImg = document.createElement("img")
+      statImg.src = stat.img
+      statImg.alt = stat.title
+      statImg.title = stat.title
+      statElm.appendChild(statImg)
+      statElm.appendChild(stat.value)
+      statsElm.appendChild(statElm)
     }
+    wrap.appendChild(statsElm)
 
-    const at = document.createElement("div")
-    at.style.display = "flex"
-    at.style.justifyContent = "space-around"
-    at.style.marginBottom = "10px"
-    at.style.marginTop = "10px"
-    at.appendChild(t)
-    at.appendChild(a)
-
-    const f1 = document.createElement("div")
-    f1.style.display = "flex"
-    f1.style.justifyContent = "space-between"
-
-    const af1 = document.createElement("div")
-    af1.style.display = "flex"
-    const hpImg = document.createElement("img")
-    hpImg.style.width = "32px"
-    hpImg.style.height = "32px"
-    hpImg.src = "assets/icons/hp.png"
-    af1.appendChild(hpImg)
-    af1.appendChild(this.hp)
-
-    const bf1 = document.createElement("div")
-    bf1.style.display = "flex"
-    bf1.appendChild(this.atk)
-    const atkImg = document.createElement("img")
-    atkImg.style.width = "32px"
-    atkImg.style.height = "32px"
-    atkImg.src = "assets/icons/atk.png"
-    bf1.appendChild(atkImg)
-
-    f1.appendChild(af1)
-    f1.appendChild(bf1)
-
-    const f2 = document.createElement("div")
-    f2.style.display = "flex"
-    f2.style.justifyContent = "space-between"
-
-    const af2 = document.createElement("div")
-    af2.style.display = "flex"
-    const defImg = document.createElement("img")
-    defImg.style.width = "32px"
-    defImg.style.height = "32px"
-    defImg.src = "assets/icons/def.png"
-    af2.appendChild(defImg)
-    af2.appendChild(this.def)
-
-    const bf2 = document.createElement("div")
-    bf2.style.display = "flex"
-    bf2.appendChild(this.range)
-    const rangeImg = document.createElement("img")
-    rangeImg.style.width = "32px"
-    rangeImg.style.height = "32px"
-    rangeImg.src = "assets/icons/range.png"
-    bf2.appendChild(rangeImg)
-
-    f2.appendChild(af2)
-    f2.appendChild(bf2)
-
-    const f3 = document.createElement("div")
-    f3.style.display = "flex"
-    f3.style.justifyContent = "space-between"
-
-    const af3 = document.createElement("div")
-    af3.style.display = "flex"
-    const speDefImg = document.createElement("img")
-    speDefImg.style.width = "32px"
-    speDefImg.style.height = "32px"
-    speDefImg.src = "assets/icons/speDef.png"
-    af3.appendChild(speDefImg)
-    af3.appendChild(this.speDef)
-
-    const bf3 = document.createElement("div")
-    bf3.style.display = "flex"
-    bf3.appendChild(this.atkSpeed)
-    const atkSpeedImg = document.createElement("img")
-    atkSpeedImg.style.width = "32px"
-    atkSpeedImg.style.height = "32px"
-    atkSpeedImg.src = "assets/icons/atkSpeed.png"
-    bf3.appendChild(atkSpeedImg)
-
-    f3.appendChild(af3)
-    f3.appendChild(bf3)
-
-    const f4 = document.createElement("div")
-    f4.style.display = "flex"
-    f4.style.justifyContent = "space-between"
-
-    const af4 = document.createElement("div")
-    af4.style.display = "flex"
-    const manaImg = document.createElement("img")
-    manaImg.style.width = "32px"
-    manaImg.style.height = "32px"
-    manaImg.src = "assets/icons/mana.png"
-    af4.appendChild(manaImg)
-    af4.appendChild(this.mana)
-
-    const bf4 = document.createElement("div")
-    bf4.style.display = "flex"
-    bf4.appendChild(this.critChance)
-    const critChangeImg = document.createElement("img")
-    critChangeImg.style.width = "32px"
-    critChangeImg.style.height = "32px"
-    critChangeImg.src = "assets/icons/critChance.png"
-    bf4.appendChild(critChangeImg)
-
-    f4.appendChild(af4)
-    f4.appendChild(bf4)
-
-    const f5 = document.createElement("div")
-    f5.style.display = "flex"
-    f5.style.justifyContent = "space-between"
-
-    const af5 = document.createElement("div")
-    af5.style.display = "flex"
-    const spellDamageImg = document.createElement("img")
-    spellDamageImg.style.width = "32px"
-    spellDamageImg.style.height = "32px"
-    spellDamageImg.src = "assets/icons/spellDamage.png"
-    af5.appendChild(spellDamageImg)
-    af5.appendChild(this.spellDamage)
-
-    const bf5 = document.createElement("div")
-    bf5.style.display = "flex"
-    bf5.appendChild(this.critDamage)
-    const critDamageImg = document.createElement("img")
-    critDamageImg.style.width = "32px"
-    critDamageImg.style.height = "32px"
-    critDamageImg.src = "assets/icons/critDamage.png"
-    bf5.appendChild(critDamageImg)
-
-    f5.appendChild(af5)
-    f5.appendChild(bf5)
-
-    f1.style.height = "35px"
-    f2.style.height = "35px"
-    f3.style.height = "35px"
-    f4.style.height = "35px"
-    f5.style.height = "35px"
-
-    profile.appendChild(avatar)
-    profile.appendChild(pokemonName)
-
-    const ult = document.createElement("p")
-    ult.innerHTML = AbilityName[skill].eng
+    const ult = document.createElement("div")
+    ult.className = "game-pokemon-detail-ult"
+    const ultName = document.createElement("p")
+    ultName.textContent = AbilityName[skill].eng
 
     const description = document.createElement("p")
-    description.innerHTML = AbilityDescription[skill].eng
+    description.textContent = AbilityDescription[skill].eng
 
-    const ultDiv = document.createElement("div")
-    ultDiv.style.display = "flex"
-    ultDiv.style.flexFlow = "column"
-    ultDiv.style.textAlign = "justify"
-    ultDiv.style.maxWidth = "200px"
-    ultDiv.style.marginLeft = "10px"
+    ult.appendChild(ultName)
+    ult.appendChild(description)
+    wrap.appendChild(ult)
 
-    ultDiv.appendChild(ult)
-    ultDiv.appendChild(description)
-
-    infos.appendChild(profile)
-    infos.appendChild(at)
-    infos.appendChild(f1)
-    infos.appendChild(f2)
-    infos.appendChild(f3)
-    infos.appendChild(f4)
-    infos.appendChild(f5)
-
-    wrap.appendChild(infos)
-    wrap.appendChild(ultDiv)
     this.dom.appendChild(wrap)
     this.setElement(this.dom)
   }
 
   updateValue(el: HTMLElement, previousValue: number, value: number) {
-    el.innerHTML = value.toString()
+    el.textContent = value.toString()
   }
-}
-
-function capitalizeFirstLetter(s: string) {
-  return s.charAt(0).toUpperCase() + s.slice(1)
 }

--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -23,13 +23,15 @@ import {
   Orientation,
   PokemonActionState,
   SpriteType,
-  PokemonTint
+  PokemonTint,
+  Rarity
 } from "../../../../types/enum/Game"
 import { Ability } from "../../../../types/enum/Ability"
 import ManaBar from "./mana-bar"
 import { Synergy } from "../../../../types/enum/Synergy"
 
 export default class Pokemon extends Button {
+  rarity: Rarity
   emotion: Emotion
   shiny: boolean
   isPopup: boolean
@@ -103,6 +105,7 @@ export default class Pokemon extends Button {
       this.index = "0000"
     }
     this.name = pokemon.name
+    this.rarity = pokemon.rarity
     this.id = pokemon.id
     this.hp = pokemon.hp
     this.range = pokemon.range
@@ -246,6 +249,7 @@ export default class Pokemon extends Button {
             0,
             0,
             this.name,
+            this.rarity,
             this.life,
             this.atk,
             this.def,
@@ -269,6 +273,7 @@ export default class Pokemon extends Button {
             0,
             0,
             this.name,
+            this.rarity,
             this.hp,
             this.atk,
             this.def,

--- a/app/public/src/pages/component/game/game-pokemon-detail.css
+++ b/app/public/src/pages/component/game/game-pokemon-detail.css
@@ -1,0 +1,86 @@
+.__react_component_tooltip.game-pokemon-detail-tooltip {
+    padding: 5px;
+}
+
+.game-pokemon-detail {
+    color: #fff;
+    font-size: 16px;
+    display: grid;
+    max-width: 320px;
+    gap: 5px;
+    grid-template-columns: 88px 1fr auto;
+    grid-template-areas:
+    "portrait entry types"
+    "stats stats stats"
+    "ult ult ult";
+}
+
+.game-pokemon-detail p {
+    margin: 0;
+}
+
+.game-pokemon-detail-entry {
+    display: flex;
+    flex-direction: column;
+    align-items: start;
+    justify-content: space-between;
+    grid-area: entry;
+}
+
+.game-pokemon-detail-entry-name {
+    text-transform: capitalize;
+    font-size: 1.2em;
+}
+
+.game-pokemon-detail-entry-rarity {
+    font-size: 85%;
+}
+
+.game-pokemon-detail-portrait {
+    width: 80px;
+    height: 80px;
+    grid-area: portrait;
+    border-style: solid;
+    border-width: 4px;
+    border-radius: 8px;
+    image-rendering: pixelated;
+    box-sizing: content-box;
+}
+
+.game-pokemon-detail-types {
+    display: flex;
+}
+
+.game-pokemon-detail-stats {
+    grid-area: stats;
+    display: grid;
+    grid-template: 32px 32px / repeat(5, 1fr)
+}
+
+.in-shop .game-pokemon-detail-stats {
+    grid-template: 32px 32px / repeat(3, 1fr)
+}
+
+.game-pokemon-detail-stats img {
+    width: 32px;
+    height: 32px;
+}
+
+.game-pokemon-detail-stats img + p {
+    display: inline-block;
+    vertical-align: middle;
+}
+
+.game-pokemon-detail-ult {
+    grid-area: ult;
+}
+
+.game-pokemon-detail-ult p:first-of-type {
+    background-color: #4F5160;
+    text-transform: capitalize;
+    font-variant: small-caps;
+    padding: 0.25em 0.5em;
+    margin: 0 -5px 4px -5px;
+    font-size: 1.2em;
+    box-shadow: 0 -1px 2px rgb(0 0 0 / 50%);
+}

--- a/app/public/src/pages/component/game/game-pokemon-detail.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-detail.tsx
@@ -1,87 +1,68 @@
 import React from "react"
 import { Pokemon } from "../../../../../models/colyseus-models/pokemon"
-import { RarityColor } from "../../../../../types/Config"
-import {
-  AbilityName,
-  AbilityDescription,
-} from "../../../../../types/strings/Ability"
+import { AttackTypeColor, RarityColor } from "../../../../../types/Config"
+import { Ability } from "../../../../../types/enum/Ability"
+import { AbilityName, AbilityDescription } from "../../../../../types/strings/Ability"
+import { AttackTypeLabel } from "../../../../../types/strings/AttackType"
 import { getPortraitSrc } from "../../../utils"
 import SynergyIcon from "../icons/synergy-icon"
-
-const pStyle = {
-  margin: "0px",
-}
-
-const imgStyle = { width: "32px", height: "32px" }
-
-const divStyle = { display: "flex", justifyContent: "center", gap: "5px" }
+import "./game-pokemon-detail.css"
 
 export function GamePokemonDetail(props: { pokemon: Pokemon }) {
   return (
-    <div style={{ display: "flex", maxWidth: "15vw", gap: "5px" }}>
-      <div
-        style={{
-          display: "flex",
-          flexFlow: "column",
-          alignItems: "start",
-          justifyContent: "space-between",
-          gap: "5px",
-        }}
-      >
-        <img
-          style={{ width: "80px", height: "80px" }}
+    <div className="game-pokemon-detail in-shop">
+      <img
+          className="game-pokemon-detail-portrait"
+          style={{ borderColor: RarityColor[props.pokemon.rarity] }}
           src={getPortraitSrc(
             props.pokemon.index,
             props.pokemon.shiny,
             props.pokemon.emotion
           )}
-        />
+      />
+      <div className="game-pokemon-detail-entry">
+        <p className="game-pokemon-detail-entry-name">{props.pokemon.name}</p>
+        <p className="game-pokemon-detail-entry-rarity" style={{color: RarityColor[props.pokemon.rarity]}}>{props.pokemon.rarity}</p>
+        <p className="game-pokemon-detail-entry-attack-type" style={{color: AttackTypeColor[props.pokemon.attackType]}}>{AttackTypeLabel[props.pokemon.attackType].eng}</p>
+      </div>
+
+      <div className="game-pokemon-detail-types">
+        {props.pokemon.types.map((type) => (
+          <SynergyIcon type={type} key={type} />
+        ))}
+      </div>
+               
+      <div className="game-pokemon-detail-stats">
         <div>
-          {props.pokemon.types.map((type) => (
-            <SynergyIcon type={type} key={type} />
-          ))}
+          <img src="assets/icons/hp.png" />
+          <p>{props.pokemon.hp}</p>
         </div>
-        <p style={{ color: RarityColor[props.pokemon.rarity] }}>
-          {props.pokemon.rarity}
-        </p>
-      </div>
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          flexFlow: "column",
-          gap: "5px",
-        }}
-      >
-        <div style={divStyle}>
-          <img style={imgStyle} src={"assets/icons/hp.png"} />
-          <p style={pStyle}>{props.pokemon.hp}</p>
+        <div>
+          <img src="assets/icons/def.png" />
+          <p>{props.pokemon.def}</p>
         </div>
-        <div style={divStyle}>
-          <img style={imgStyle} src={"assets/icons/atk.png"} />
-          <p style={pStyle}>{props.pokemon.atk}</p>
+        <div>
+          <img src="assets/icons/atk.png" />
+          <p>{props.pokemon.atk}</p>
         </div>
-        <div style={divStyle}>
-          <img style={imgStyle} src={"assets/icons/def.png"} />
-          <p style={pStyle}>{props.pokemon.def}</p>
-        </div>
-        <div style={divStyle}>
-          <img style={imgStyle} src={"assets/icons/speDef.png"} />
-          <p style={pStyle}>{props.pokemon.speDef}</p>
-        </div>
-        <div style={divStyle}>
-          <img style={imgStyle} src={"assets/icons/range.png"} />
-          <p style={pStyle}>{props.pokemon.range}</p>
-        </div>
-        <div style={divStyle}>
-          <img style={imgStyle} src={"assets/icons/mana.png"} />
-          <p style={pStyle}>{props.pokemon.maxMana}</p>
+        <div>
+          <img src="assets/icons/mana.png" />
+          <p>{props.pokemon.maxMana}</p>
+        </div>        
+        <div>
+          <img src="assets/icons/speDef.png" />
+          <p>{props.pokemon.speDef}</p>
+        </div>        
+        <div>
+          <img src="assets/icons/range.png" />
+          <p>{props.pokemon.range}</p>
         </div>
       </div>
-      <div>
-        <p style={pStyle}>{AbilityName[props.pokemon.skill].eng}</p>
-        <p style={pStyle}>{AbilityDescription[props.pokemon.skill].eng}</p>
-      </div>
+
+      {props.pokemon.skill !== Ability.DEFAULT && <div className="game-pokemon-detail-ult">
+        <p>{AbilityName[props.pokemon.skill].eng}</p>
+        <p>{AbilityDescription[props.pokemon.skill].eng}</p>
+      </div>}
     </div>
   )
 }

--- a/app/public/src/pages/component/game/game-pokemon-portrait.tsx
+++ b/app/public/src/pages/component/game/game-pokemon-portrait.tsx
@@ -51,7 +51,7 @@ export default function GamePokemonPortrait(props: {
       >
         <ReactTooltip
           id={"shop-" + props.index}
-          className="customeTheme"
+          className="customeTheme game-pokemon-detail-tooltip"
           effect="solid"
           place="bottom"
         >

--- a/app/public/src/pages/component/icons/synergy-icon.tsx
+++ b/app/public/src/pages/component/icons/synergy-icon.tsx
@@ -8,7 +8,8 @@ export default function SynergyIcon(props: {
 }) {
   return (
     <img src={"assets/types/" + props.type + ".png"} 
-         alt={props.type} 
+         alt={props.type}
+         title={props.type}
          className="synergy-icon"
          style={{ width: props.size ?? '34px', height: props.size ?? '34px', imageRendering: "pixelated" }}
     />

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -2,7 +2,7 @@ import { Synergy } from "./enum/Synergy"
 import { Pkm, PkmIndex } from "./enum/Pokemon"
 import { Item } from "./enum/Item"
 import { Effect } from "./enum/Effect"
-import { Rarity } from "./enum/Game"
+import { AttackType, Rarity } from "./enum/Game"
 import { Emotion } from "."
 
 export const RarityHpCost: { [key in Rarity]: number } = Object.freeze({
@@ -80,6 +80,13 @@ export const RarityColor: { [key in Rarity]: string } = {
   [Rarity.MYTHICAL]: "#ffc0cb",
   [Rarity.SUMMON]: "#991f1f"
 }
+
+export const AttackTypeColor: { [key in AttackType] } = {
+  [AttackType.PHYSICAL]: "#FF6E55",
+  [AttackType.SPECIAL]: "#7FC9FF",
+  [AttackType.TRUE]: "#FFD800"
+}
+
 export const Probability: { [key: number]: number[] } = {
   1: [1, 0, 0, 0, 0],
   2: [1, 0, 0, 0, 0],

--- a/app/types/strings/AttackType.ts
+++ b/app/types/strings/AttackType.ts
@@ -1,0 +1,25 @@
+import { Langage } from "..";
+import { AttackType } from "../enum/Game";
+
+export const AttackTypeLabel: { [key in AttackType]: Langage } = {
+  [AttackType.PHYSICAL]: {
+    eng: "Physical",
+    esp: "Físico",
+    fra: "Physique",
+    prt: "Físico"
+  },
+
+  [AttackType.SPECIAL]: {
+    eng: "Special",
+    esp: "Especial",
+    fra: "Spécial",
+    prt: "Especial"
+  },
+
+  [AttackType.TRUE]: {
+    eng: "True",
+    esp: "Bruto",
+    fra: "Brut",
+    prt: "Bruto"
+  },
+};


### PR DESCRIPTION
Some players were complaining that they were missing some information on the tooltip after buying a Pokemon, so I redesigned them. They are now very similar between pokemons in the shop and on board.

On board:

Before:
![image](https://user-images.githubusercontent.com/566536/211948486-f68972de-371f-4938-9c08-204f86f1a2c3.png)

After:
![image](https://user-images.githubusercontent.com/566536/211948525-1c3b7fbc-2b95-460f-a664-20d3effde9d8.png)

In the shop:

Before:
![image](https://user-images.githubusercontent.com/566536/211948631-43e02252-bbb9-4bc0-876c-4f43303578a9.png)

After:
![image](https://user-images.githubusercontent.com/566536/211948649-75177a60-5b96-41ed-ae4c-90578434384c.png)


