### PR TITLE
fix max level label

### DIFF
--- a/app/public/src/pages/component/game/game-experience.tsx
+++ b/app/public/src/pages/component/game/game-experience.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import CSS from "csstype"
 import { useAppSelector } from "../../../hooks"
 import { useAppDispatch } from "../../../hooks"
 import { levelClick } from "../../../stores/NetworkStore"
@@ -11,13 +10,7 @@ export default function GameExperience() {
   const experienceManager = useAppSelector(
     (state) => state.game.experienceManager
   )
-
-  let progressString = ""
-  if (Number(experienceManager.expNeeded) == -1) {
-    progressString = "Max Level"
-  } else {
-    progressString = experienceManager.experience + "/" + experienceManager.expNeeded
-  }
+  const isLevelMax = experienceManager.level >= 9
 
   return (
     <div className="nes-container game-experience">
@@ -32,10 +25,10 @@ export default function GameExperience() {
       <div className="progress-bar">
         <progress
           className="nes-progress"
-          value={experienceManager.experience}
+          value={isLevelMax ? 0 : experienceManager.experience}
           max={experienceManager.expNeeded}
         ></progress>
-        <span>{progressString}</span>
+        <span>{isLevelMax ? "Max Level" : experienceManager.experience + "/" + experienceManager.expNeeded}</span>
       </div>
     </div>
   )

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -36,7 +36,7 @@ export const ExpTable: { [key: number]: number } = Object.freeze({
   6: 32,
   7: 50,
   8: 70,
-  9: -1
+  9: 255
 })
 
 export const TypeTrigger: { [key in Synergy]: number[] } = {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/566536/214910998-a6211be7-6f34-4312-b38c-8c434bef3bb9.png)

After:
![image](https://user-images.githubusercontent.com/566536/214911019-f11cd026-3279-457d-860e-95a28edfe77b.png)

expNeeded is defined as uint8 so -1 is not a valid value, was converted to 255
I hard-coded the max level on client side, but if you prefer we can also share the info in the colyseus schema