### PR TITLE
pokemon per rarity in wiki types

### DIFF
--- a/app/public/src/pages/component/wiki/wiki-type.tsx
+++ b/app/public/src/pages/component/wiki/wiki-type.tsx
@@ -6,17 +6,24 @@ import {
   SynergyDetail
 } from "../../../../../types/strings/Synergy"
 import { EffectName } from "../../../../../types/strings/Effect"
-import { TypeTrigger } from "../../../../../types/Config"
+import { TypeTrigger, RarityColor } from "../../../../../types/Config"
 import { Synergy } from "../../../../../types/enum/Synergy"
-import { Pkm, PkmIndex } from "../../../../../types/enum/Pokemon"
+import { Pkm } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../utils"
 import SynergyIcon from "../icons/synergy-icon"
 import { SynergyDescription } from "../synergy/synergy-description"
 import { GamePokemonDetail } from "../game/game-pokemon-detail"
 import PokemonFactory from "../../../../../models/pokemon-factory";
+import { groupBy } from "../../../../../utils/array";
+import { Pokemon } from "../../../../../models/colyseus-models/pokemon";
+import { Rarity } from "../../../../../types/enum/Game";
 
 export default function WikiType(props: { type: Synergy }) {
   const [hoveredPokemon, setHoveredPokemon] = useState<Pokemon>();
+  const firstStagePokemons = (PRECOMPUTED_TYPE_POKEMONS_ALL[props.type] as Pkm[])
+    .map(p => PokemonFactory.createPokemonFromName(p))
+    .filter(p => p.stars === 1 || p.rarity === Rarity.MYTHICAL)
+  const pokemonsPerRarity = groupBy(firstStagePokemons, p => p.rarity)
   return (
     <div style={{padding: "1em"}}>
       <div style={{ display: "flex", marginBottom: "0.5em" }}>
@@ -33,15 +40,20 @@ export default function WikiType(props: { type: Synergy }) {
           </div>
         )
       })}
-      <div style={{ display: "flex", flexWrap: "wrap" }}>
-        {(PRECOMPUTED_TYPE_POKEMONS_ALL[props.type] as Pkm[]).map((p) => {
-          return <img key={p} src={getPortraitSrc(PkmIndex[p])} alt={p} title={p}
-          data-tip data-for="pokemon-detail"
-          onMouseOver={() => { 
-            setHoveredPokemon(PokemonFactory.createPokemonFromName(p)) 
-          }} />
+      <table>
+        {(Object.values(Rarity) as Rarity[]).map(rarity => {
+          return <tr>
+            <td style={{ color: RarityColor[rarity] }}>{rarity}</td>
+            <td>{(pokemonsPerRarity[rarity] ?? []).map(p => {
+              return <img key={p.name} src={getPortraitSrc(p.index)} alt={p.name} title={p.name}
+                data-tip data-for="pokemon-detail"
+                onMouseOver={() => {
+                  setHoveredPokemon(p)
+                }} />})}
+            </td>
+          </tr>
         })}
-      </div>
+      </table>
       {hoveredPokemon && <ReactTooltip
         id="pokemon-detail"
         className="customeTheme game-pokemon-detail-tooltip"

--- a/app/utils/array.ts
+++ b/app/utils/array.ts
@@ -1,0 +1,7 @@
+export const groupBy = <T, K extends keyof any>(arr: T[], key: (i: T) => K) =>
+  arr.reduce((groups, item) => {
+    const k = key(item);
+    if(!(k in groups)) groups[k] = [];
+    groups[k].push(item);
+    return groups;
+  }, {} as Record<K, T[]>);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/566536/218595873-c7723d47-087f-4c49-b34b-97f7cbcca2b2.png)

This should help for balancing the distribution per synergies/rarities

My notes:
water: distribution is weird (8 uncommon, 1 rare, 4 epic, no legendary)
dark: very dependent on cacnea (only rare)
ground & poison: only one uncommon, too many rare
bug & flying: no epic
rock & artificial: only one common, no uncommon

discussed here https://discord.com/channels/737230355039387749/1065799578378580029/1074826425305153648
