### PR TITLE
Bugfix ditto hatch

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -210,7 +210,7 @@ export class OnDragDropCommand extends Command<
             pokemonToClone &&
             pokemonToClone.rarity !== Rarity.MYTHICAL &&
             pokemonToClone.rarity !== Rarity.NEUTRAL &&
-            !pokemonToClone.types.includes(Synergy.FOSSIL)
+            pokemonToClone.rarity !== Rarity.HATCH
           ) {
             dittoReplaced = true
             const replaceDitto = PokemonFactory.createPokemonFromName(

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -773,7 +773,7 @@ export default class GameRoom extends Room<GameState> {
     let pkm: Pokemon | undefined = undefined
     let found = false
     board.forEach((pokemon, key) => {
-      if (pokemon.positionY == 0 && pokemon.name != Pkm.DITTO && !found) {
+      if (pokemon.positionY == 0 && pokemon.rarity != Rarity.NEUTRAL && !found) {
         found = true
         pkm = pokemon
       }


### PR DESCRIPTION
- prevent duplication of hatch pokemon
- enable duplication of pokemons with old amber
- prevent eggs being pushed on board to fill available space