### PR TITLE
fix rarity probability

### DIFF
--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -40,6 +40,8 @@ import PokemonConfig from "../models/colyseus-models/pokemon-config"
 import { nanoid } from "nanoid"
 import PRECOMPUTED_RARITY_POKEMONS from "../models/precomputed/type-rarity-all.json"
 import { Rarity } from "../types/enum/Game"
+import { pickRandomIn } from "../utils/random"
+import { sum } from "../utils/array"
 
 export default class CustomLobbyRoom extends LobbyRoom {
   discordWebhook: WebhookClient | undefined
@@ -87,7 +89,7 @@ export default class CustomLobbyRoom extends LobbyRoom {
   pickPokemon(): Pkm {
     let pkm = Pkm.MAGIKARP
     const rarities = Object.keys(Rarity) as Rarity[]
-    const seed = Math.random()
+    const seed = Math.random() * sum(Object.values(RarityProbability))
     let threshold = 0
     for (let i = 0; i < rarities.length; i++) {
       const rarity = rarities[i]
@@ -98,13 +100,8 @@ export default class CustomLobbyRoom extends LobbyRoom {
         this.precomputedRarityPokemons[rarity] &&
         this.precomputedRarityPokemons[rarity].length > 0
       ) {
-        pkm =
-          this.precomputedRarityPokemons[rarity][
-            Math.floor(
-              Math.random() * this.precomputedRarityPokemons[rarity].length
-            )
-          ]
-        break
+        pkm = pickRandomIn(this.precomputedRarityPokemons[rarity])
+        break;
       }
     }
     return pkm

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -113,15 +113,15 @@ export const RarityColor: { [key in Rarity]: string } = {
 }
 
 export const RarityProbability: { [key in Rarity]: number } = {
-  [Rarity.COMMON]: 0.25,
+  [Rarity.COMMON]: 0.15,
   [Rarity.NEUTRAL]: 0,
   [Rarity.UNCOMMON]: 0.2,
   [Rarity.RARE]: 0.2,
   [Rarity.EPIC]: 0.15,
   [Rarity.LEGENDARY]: 0.05,
-  [Rarity.MYTHICAL]: 0,
+  [Rarity.MYTHICAL]: 0.15,
   [Rarity.SUMMON]: 0,
-  [Rarity.HATCH]: 0
+  [Rarity.HATCH]: 0.1
 }
 
 export const AttackTypeColor: { [key in AttackType] } = {

--- a/app/utils/array.ts
+++ b/app/utils/array.ts
@@ -5,3 +5,7 @@ export const groupBy = <T, K extends keyof any>(arr: T[], key: (i: T) => K) =>
     groups[k].push(item);
     return groups;
   }, {} as Record<K, T[]>);
+
+export function sum(arr: number[]): number {
+  return arr.reduce((a,b) => a+b, 0)
+}


### PR DESCRIPTION
boosters are bugged because of rarity probability not being summed to 1 ; causing this
![image](https://user-images.githubusercontent.com/566536/219983926-6e2eeca7-1b01-4ae0-bdc0-b9a4ce097b8c.png)


I changed the probabilities and updated the code so that it won't happen in the future even if probs are not summed to 1