### PR TITLE
fix additional pokemons grid css

### DIFF
--- a/app/public/src/pages/component/game/game-shop.css
+++ b/app/public/src/pages/component/game/game-shop.css
@@ -57,7 +57,7 @@
 
 .game-additional-pokemons {
   display: grid;
-  grid-template: 1fr 1fr 1fr 1fr/ 1fr 1fr 1fr 1fr;
+  grid-template: repeat(4, 1fr) / repeat(4, 1fr);
   padding: 0 !important;
   color: white;
   background-color: rgb(97, 115, 138);
@@ -71,6 +71,8 @@
   object-fit: cover;
   width: 100%;
   height: 100%;
+  min-height: 0;
+  min-width: 0;
   border: 1px solid #333;
 }
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/566536/220210532-c84f3233-0277-4d87-b23d-232ccaabc621.png)

16 pokemons should be displayed, not 12. This fix it