### PR TITLE
Wonder guard nerf

### DIFF
--- a/app/core/attack-strategy.ts
+++ b/app/core/attack-strategy.ts
@@ -2656,7 +2656,7 @@ export class AppleAcidStrategy extends AttackStrategy {
         break
     }
     target.handleSpellDamage(damage, board, AttackType.SPECIAL, pokemon)
-    pokemon.handleHeal(Math.floor(damage / 2), pokemon)
+    pokemon.addSpecialDefense(-3, true)
   }
 }
 

--- a/app/core/attack-strategy.ts
+++ b/app/core/attack-strategy.ts
@@ -2655,8 +2655,8 @@ export class AppleAcidStrategy extends AttackStrategy {
       default:
         break
     }
-    target.handleSpellDamage(damage, board, AttackType.SPECIAL, pokemon)
     pokemon.addSpecialDefense(-3, true)
+    target.handleSpellDamage(damage, board, AttackType.SPECIAL, pokemon)    
   }
 }
 

--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -353,14 +353,14 @@ export default class AttackingState extends PokemonState {
       }
 
       if (pokemon.items.has(Item.LEFTOVERS)) {
-        pokemon.handleHeal(pokemon.hp * 0.05, pokemon)
+        pokemon.handleHeal(pokemon.hp * 0.05, pokemon, false)
         ;[-1, 0, 1].forEach((offset) => {
           const value = board.getValue(
             pokemon.positionX + offset,
             pokemon.positionY
           )
           if (value && value.team === pokemon.team) {
-            value.handleHeal(value.hp * 0.05, pokemon)
+            value.handleHeal(value.hp * 0.05, pokemon, false)
           }
         })
       }

--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -194,8 +194,7 @@ export default class AttackingState extends PokemonState {
                 board,
                 AttackType.SPECIAL,
                 pokemon,
-                false,
-                true
+                false
               )
             }
           })
@@ -226,8 +225,7 @@ export default class AttackingState extends PokemonState {
                 board,
                 AttackType.SPECIAL,
                 target,
-                false,
-                true
+                false
               )
             }
           })
@@ -246,7 +244,6 @@ export default class AttackingState extends PokemonState {
           board,
           AttackType.TRUE,
           pokemon,
-          true,
           true
         )
       }
@@ -259,7 +256,6 @@ export default class AttackingState extends PokemonState {
           board,
           AttackType.TRUE,
           pokemon,
-          true,
           true
         )
       }
@@ -272,7 +268,6 @@ export default class AttackingState extends PokemonState {
           board,
           AttackType.TRUE,
           pokemon,
-          true,
           true
         )
       }
@@ -285,7 +280,6 @@ export default class AttackingState extends PokemonState {
           board,
           AttackType.TRUE,
           pokemon,
-          true,
           true
         )
       }
@@ -297,13 +291,12 @@ export default class AttackingState extends PokemonState {
           board,
           AttackType.SPECIAL,
           target,
-          false,
-          true
+          false
         )
       }
 
       if (damage > 0) {
-        target.handleDamage(damage, board, attackType, pokemon, true, true)
+        target.handleDamage(damage, board, attackType, pokemon, true)
       }
 
       if (pokemon.items.has(Item.BLUE_ORB)) {
@@ -330,7 +323,6 @@ export default class AttackingState extends PokemonState {
             board,
             AttackType.TRUE,
             pokemon,
-            true,
             true
           )
         }
@@ -353,7 +345,6 @@ export default class AttackingState extends PokemonState {
               board,
               attackType,
               pokemon,
-              true,
               true
             )
             targetCount--

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -159,8 +159,7 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
     board: Board,
     attackType: AttackType,
     attacker: PokemonEntity,
-    dodgeable: boolean,
-    reduceable: boolean
+    dodgeable: boolean
   ) {
     return this.state.handleDamage(
       this,
@@ -168,8 +167,7 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
       board,
       attackType,
       attacker,
-      dodgeable,
-      reduceable
+      dodgeable
     )
   }
 
@@ -209,13 +207,12 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
         board,
         attackType,
         attacker,
-        false,
-        true
+        false
       )
     }
   }
 
-  handleHeal(heal: number, caster: IPokemonEntity, spellDamageBoost?: boolean) {
+  handleHeal(heal: number, caster: IPokemonEntity, spellDamageBoost: boolean) {
     return this.state.handleHeal(this, heal, caster, spellDamageBoost)
   }
 

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -281,11 +281,12 @@ export default class PokemonState {
             }
             attacker.handleHeal(
               Math.floor(lifesteal * residualDamage),
-              attacker
+              attacker,
+              false
             )
           }
           if (attacker.items.has(Item.SHELL_BELL)) {
-            attacker.handleHeal(Math.floor(0.3 * residualDamage), attacker)
+            attacker.handleHeal(Math.floor(0.3 * residualDamage), attacker, false)
           }
 
           if (
@@ -358,7 +359,7 @@ export default class PokemonState {
                   value.types.includes(Synergy.FIELD)
                 ) {
                   value.count.fieldCount++
-                  value.handleHeal((boost / 100) * value.hp, pokemon)
+                  value.handleHeal((boost / 100) * value.hp, pokemon, false)
                   value.handleAttackSpeed(speedBoost)
                 }
               })
@@ -411,7 +412,7 @@ export default class PokemonState {
           }
           attacker.addSpecialDefense(defBoost)
           attacker.addDefense(defBoost)
-          attacker.handleHeal(healBoost, attacker)
+          attacker.handleHeal(healBoost, attacker, false)
           attacker.addAttack(attackBoost)
           attacker.count.monsterExecutionCount++
         }

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -25,10 +25,13 @@ export default class PokemonState {
       !pokemon.status.wound
     ) {
       const boost = spellDamageBoost ? (heal * pokemon.spellDamage) / 100 : 0
-      const healBoosted = Math.round(heal + boost)
-      const healTaken = Math.round(
-        Math.min(pokemon.hp - pokemon.life, healBoosted)
-      )
+      let healBoosted = Math.round(heal + boost)
+      if(pokemon.skill === Ability.WONDER_GUARD){
+        healBoosted = 1
+      }
+
+      const healTaken = Math.min(pokemon.hp - pokemon.life, healBoosted)
+
       pokemon.life = Math.min(pokemon.hp, pokemon.life + healBoosted)
 
       if (caster && healTaken > 0) {
@@ -79,8 +82,7 @@ export default class PokemonState {
     board: Board,
     attackType_: AttackType,
     attacker: PokemonEntity,
-    dodgeable: boolean,
-    reduceable: boolean
+    dodgeable: boolean
   ): boolean {
     let death: boolean
     let attackType = attackType_
@@ -151,7 +153,7 @@ export default class PokemonState {
         }
 
         if (
-          reduceable &&
+          attackType !== AttackType.TRUE &&
           (pokemon.effects.includes(Effect.GUTS) ||
             pokemon.effects.includes(Effect.DEFIANT) ||
             pokemon.effects.includes(Effect.JUSTIFIED))

--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -271,7 +271,7 @@ export default class Simulation extends Schema implements ISimulation {
         pokemon.handleShield(value, pokemon)
         break
       case Stat.HP:
-        pokemon.handleHeal(value, pokemon)
+        pokemon.handleHeal(value, pokemon, false)
         break
     }
   }

--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -202,7 +202,6 @@ export default class Status extends Schema implements IStatus {
           board,
           AttackType.TRUE,
           this.burnOrigin,
-          false,
           false
         )
         this.burnDamageCooldown = 1000
@@ -278,7 +277,6 @@ export default class Status extends Schema implements IStatus {
           board,
           AttackType.TRUE,
           this.poisonOrigin,
-          false,
           false
         )
         this.poisonDamageCooldown = 1000

--- a/app/types/strings/Ability.ts
+++ b/app/types/strings/Ability.ts
@@ -1220,7 +1220,7 @@ export const AbilityDescription: { [key in Ability]: Langage } = {
     fra: ``
   },
   WONDER_GUARD: {
-    eng: `Passive: Reduce received damage to 1`,
+    eng: `Passive: Reduce received damage and received healing to 1`,
     esp: ``,
     prt: ``,
     fra: ``


### PR DESCRIPTION
Ninjask wonder guard ability with leftovers/grass stone makes it unkillable, leading to draws every time. 

I changed wonder guard so that healing received is reduced to 1 as well, as discussed here: https://discord.com/channels/737230355039387749/737244224688226346/1079105652129009774

Other changes:
- Apple Acid was doing healing, changed strategy to match with the ability description
- True damage was being blocked by Fighting abilities, changed so that it's no longer the case (that was noticeable with early Ghost vs Fighting battles)