### PR TITLE
revert petal dance nerf

### DIFF
--- a/app/core/attack-strategy.ts
+++ b/app/core/attack-strategy.ts
@@ -1282,15 +1282,15 @@ export class PetalDanceStrategy extends AttackStrategy {
 
     switch (pokemon.stars) {
       case 1:
-        damage = 20
+        damage = 25
         count = 2
         break
       case 2:
-        damage = 40
+        damage = 50
         count = 4
         break
       case 3:
-        damage = 60
+        damage = 100
         count = 6
         break
       default:

--- a/app/models/colyseus-models/pokemon.ts
+++ b/app/models/colyseus-models/pokemon.ts
@@ -1295,7 +1295,7 @@ export class Budew extends Pokemon {
   constructor(shiny: boolean, emotion: Emotion) {
     super(
       Pkm.BUDEW,
-      [Synergy.BABY, Synergy.POISON, Synergy.FLORA],
+      [Synergy.GRASS, Synergy.POISON, Synergy.BABY],
       Rarity.EPIC,
       Pkm.ROSELIA,
       90,
@@ -1319,7 +1319,7 @@ export class Roselia extends Pokemon {
   constructor(shiny: boolean, emotion: Emotion) {
     super(
       Pkm.ROSELIA,
-      [Synergy.POISON, Synergy.FLORA],
+      [Synergy.GRASS, Synergy.POISON, Synergy.FLORA],
       Rarity.EPIC,
       Pkm.ROSERADE,
       130,
@@ -1343,7 +1343,7 @@ export class Roserade extends Pokemon {
   constructor(shiny: boolean, emotion: Emotion) {
     super(
       Pkm.ROSERADE,
-      [Synergy.POISON, Synergy.FLORA],
+      [Synergy.GRASS, Synergy.POISON, Synergy.FLORA],
       Rarity.EPIC,
       Pkm.DEFAULT,
       230,

--- a/app/types/strings/Ability.ts
+++ b/app/types/strings/Ability.ts
@@ -782,7 +782,7 @@ export const AbilityDescription: { [key in Ability]: Langage } = {
     prt: ``
   },
   [Ability.PETAL_DANCE]: {
-    eng: `Deals [20,40,60] ${Damage.SPECIAL} to [2,4,6] ennemies`,
+    eng: `Deals [25,50,100] ${Damage.SPECIAL} to [2,4,6] ennemies`,
     esp: ``,
     fra: ``,
     prt: ``


### PR DESCRIPTION
Now that Snivy does not has Petal Dance ability, this reverts the previous nerf of Petal dance damage and restore Grass synergy on Budew line

discussed here: https://discord.com/channels/737230355039387749/1077334616073044079