### PR TITLE
fix damage numbers and float number precision

### DIFF
--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -747,7 +747,7 @@ export default class BattleManager {
         .setOrigin(0, 0)
     )
     const text = this.scene.add.existing(
-      new GameObjects.Text(this.scene, 25, 0, amount.toString(), textStyle)
+      new GameObjects.Text(this.scene, 25, 0, amount.toFixed(0), textStyle)
     )
     image.setDepth(9)
     text.setDepth(10)


### PR DESCRIPTION
Sometimes the damage number shown is 30.0000000000004
This is due to float number precision in JS:
![image](https://user-images.githubusercontent.com/566536/221700638-2d3aae02-84da-43aa-8aad-650b82150d0f.png)

calling .toFixed(0) instead of toString() fixes the issue