### PR TITLE
Poison & confusion rework

### DIFF
--- a/app/core/attack-strategy.ts
+++ b/app/core/attack-strategy.ts
@@ -3019,7 +3019,7 @@ export class PoisonStingStrategy extends AttackStrategy {
       default:
         break
     }
-    if (pokemon.status.poison) {
+    if (pokemon.status.poisonStacks > 0) {
       damage = damage * 2
     }
 

--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -5,7 +5,6 @@ import Board from "./board"
 import PokemonEntity from "./pokemon-entity"
 import PokemonState from "./pokemon-state"
 import { PokemonActionState } from "../types/enum/Game"
-import { Ability } from "../types/enum/Ability"
 
 export default class AttackingState extends PokemonState {
   update(
@@ -24,7 +23,9 @@ export default class AttackingState extends PokemonState {
         y: pokemon.targetY
       }
 
-      if (
+      if(pokemon.status.confusion){
+        targetCoordinate = this.getTargetCoordinateWhenConfused(pokemon, board)
+      } else if (
         !(
           target &&
           target.team !== pokemon.team &&

--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -111,13 +111,13 @@ export default class AttackingState extends PokemonState {
 
       let poisonChance = 0
       if (pokemon.effects.includes(Effect.POISON_GAS)) {
-        poisonChance += 0.3
+        poisonChance = 0.3
       }
       if (pokemon.effects.includes(Effect.TOXIC)) {
-        poisonChance += 0.4
+        poisonChance = 0.7
       }
-      if (poisonChance != 0) {
-        if (Math.random() > 1 - poisonChance) {
+      if (poisonChance > 0) {
+        if (Math.random() < poisonChance) {
           target.status.triggerPoison(4000, target, pokemon, board)
         }
       }

--- a/app/core/board.ts
+++ b/app/core/board.ts
@@ -1,5 +1,6 @@
 import { IPokemonEntity } from "../types"
 import { Orientation } from "../types/enum/Game"
+import { pickRandomIn } from "../utils/random"
 import PokemonEntity from "./pokemon-entity"
 
 export type Cell = {
@@ -83,6 +84,9 @@ export default class Board {
       }
     } else if (vx == 0) {
       if (vy == 0) {
+        if(pokemon.status.confusion){
+          return pickRandomIn(Orientation)
+        }
         console.log("error orientation", r0, c0, r1, c1)
         console.log(
           "error pokemon",

--- a/app/core/moving-state.ts
+++ b/app/core/moving-state.ts
@@ -24,8 +24,7 @@ export default class MovingState extends PokemonState {
           pokemon.positionY,
           targetCoordinate.x,
           targetCoordinate.y
-        ) <= pokemon.range &&
-        !pokemon.status.confusion
+        ) <= pokemon.range
       ) {
         pokemon.toAttackingState()
       } else {

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -735,6 +735,42 @@ export default class PokemonState {
     }
   }
 
+  getTargetCoordinateWhenConfused(
+    pokemon: PokemonEntity,
+    board: Board
+  ): { x: number; y: number } | undefined {
+    let distance = 999
+    let candidatesCoordinates: { x: number; y: number }[] = new Array<{
+      x: number
+      y: number
+    }>()
+
+    board.forEach((r: number, c: number, value: PokemonEntity | undefined) => {
+      if (value !== undefined && value.id != pokemon.id) {
+        const candidateDistance = board.distance(
+          pokemon.positionX,
+          pokemon.positionY,
+          r,
+          c
+        )
+        if (candidateDistance < distance) {
+          distance = candidateDistance
+          candidatesCoordinates = [{ x: r, y: c }]
+        } else if (candidateDistance == distance) {
+          candidatesCoordinates.push({ x: r, y: c })
+        }
+      }
+    })
+
+    candidatesCoordinates.push({ x: pokemon.positionX, y: pokemon.positionY }) // sometimes attack itself when confused
+
+    if (candidatesCoordinates.length > 0) {
+      return pickRandomIn(candidatesCoordinates)
+    } else {
+      return undefined
+    }
+  }
+
   move(
     pokemon: PokemonEntity,
     board: Board,

--- a/app/models/colyseus-models/status.ts
+++ b/app/models/colyseus-models/status.ts
@@ -10,7 +10,7 @@ import { Item } from "../../types/enum/Item"
 export default class Status extends Schema implements IStatus {
   @type("boolean") burn = false
   @type("boolean") silence = false
-  @type("boolean") poison = false
+  @type("number") poisonStacks = 0
   @type("boolean") freeze = false
   @type("boolean") protect = false
   @type("boolean") sleep = false
@@ -74,7 +74,7 @@ export default class Status extends Schema implements IStatus {
       this.updateBurn(dt, pokemon, board)
     }
 
-    if (this.poison) {
+    if (this.poisonStacks > 0) {
       this.updatePoison(dt, pokemon, board)
     }
 
@@ -254,9 +254,9 @@ export default class Status extends Schema implements IStatus {
     origin: PokemonEntity | undefined,
     board: Board
   ) {
-    if (!this.poison && !pkm.items.has(Item.FLUFFY_TAIL)) {
-      this.poison = true
-      this.poisonCooldown = timer
+    if (pkm.items.has(Item.FLUFFY_TAIL) === false) {
+      this.poisonStacks = Math.min(3, this.poisonStacks + 1)
+      this.poisonCooldown = Math.max(timer, this.poisonCooldown)
       if (origin) {
         this.poisonOrigin = origin
       }
@@ -274,7 +274,7 @@ export default class Status extends Schema implements IStatus {
     if (this.poisonDamageCooldown - dt <= 0) {
       if (this.poisonOrigin) {
         pkm.handleDamage(
-          Math.ceil(pkm.hp * 0.13),
+          Math.ceil(pkm.hp * 0.05 * this.poisonStacks),
           board,
           AttackType.TRUE,
           this.poisonOrigin,
@@ -288,7 +288,7 @@ export default class Status extends Schema implements IStatus {
     }
 
     if (this.poisonCooldown - dt <= 0) {
-      this.poison = false
+      this.poisonStacks = 0
       this.poisonOrigin = undefined
       this.poisonDamageCooldown = 1000
     } else {

--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -747,7 +747,7 @@ export default class BattleManager {
         .setOrigin(0, 0)
     )
     const text = this.scene.add.existing(
-      new GameObjects.Text(this.scene, 25, 0, amount.toString(), textStyle)
+      new GameObjects.Text(this.scene, 25, 0, amount.toFixed(0), textStyle)
     )
     image.setDepth(9)
     text.setDepth(10)

--- a/app/public/src/game/components/battle-manager.ts
+++ b/app/public/src/game/components/battle-manager.ts
@@ -133,8 +133,8 @@ export default class BattleManager {
         const pkm = <Pokemon>children[i]
 
         if (pkm.id == pokemon.id) {
-          if (change.field == "poison") {
-            if (pokemon.status.poison) {
+          if (change.field == "poisonStacks") {
+            if (pokemon.status.poisonStacks > 0) {
               pkm.addPoison()
             } else {
               pkm.removePoison()

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -406,7 +406,7 @@ export interface IPokemonEntity {
 export interface IStatus {
   burn: boolean
   silence: boolean
-  poison: boolean
+  poisonStacks: number
   freeze: boolean
   protect: boolean
   sleep: boolean

--- a/app/types/strings/Status.ts
+++ b/app/types/strings/Status.ts
@@ -103,7 +103,7 @@ export const StatusDescription: { [key in Status]: Langage } = {
       prt: ""
     },
     [Status.POISON]: {
-      eng: `Deals 13% of max HP as ${Damage.TRUE} every second`,
+      eng: `Deals 5% of max HP per stack as ${Damage.TRUE} every second. Can stack up to 3 times.`,
       esp: "",
       fra: "",
       prt: ""
@@ -127,7 +127,7 @@ export const StatusDescription: { [key in Status]: Langage } = {
       prt: ""
     },
     [Status.CONFUSION]: {
-      eng: "Prevents attacking",
+      eng: "Force to change target all the time and sometimes deal damage to itself",
       esp: "",
       fra: "",
       prt: ""


### PR DESCRIPTION
as discussed here: https://discord.com/channels/737230355039387749/1078434093999599626

Poison: Deals 5% of max HP per stack as true damage every second. Can stack up to 3 times.

This allows to better synergize Poison teams attacking the same target. In practice, I would say it's a small nerf for Poison 3 and a small buff for Poison 6.

Confusion: Force to change target all the time and sometimes deal damage to itself

All targets at range are considered when picking a target, including the attacker itself. It is quite fun to watch compared to previous confusion effect.