### PR TITLE
fix sell prices for mythical

### DIFF
--- a/app/models/pokemon-factory.ts
+++ b/app/models/pokemon-factory.ts
@@ -507,6 +507,7 @@ import { Synergy } from "../types/enum/Synergy"
 import { Pkm, PkmFamily } from "../types/enum/Pokemon"
 import { PkmCost, EvolutionTime } from "../types/Config"
 import { pickRandomIn } from "../utils/random"
+import { Mythical1Shop } from "./shop"
 
 export const ObtainableEgg = new Array<Pkm>(
   Pkm.GOTHITA,
@@ -1763,6 +1764,8 @@ export default class PokemonFactory {
       return 2
     } else if (pokemon.rarity === Rarity.HATCH) {
       return [3, 4, 5][pokemon.stars - 1]
+    } else if (pokemon.rarity === Rarity.MYTHICAL) {
+      return Mythical1Shop.includes(name) ? 15 : 20
     } else if (PokemonFactory.getPokemonBaseEvolution(name) == Pkm.EEVEE) {
       return PkmCost[pokemon.rarity]
     } else {


### PR DESCRIPTION
selling prices of mythicals were not uniform because of their stars property

This fix the selling prices for all mythical to be 15 gold for stage 10 and 20 gold for stage 20.

discussed here: https://discord.com/channels/737230355039387749/1079535018780672090