### PR TITLE
change mons for surge status

### DIFF
--- a/app/public/src/pages/component/anim/TestStatusAnim.tsx
+++ b/app/public/src/pages/component/anim/TestStatusAnim.tsx
@@ -23,7 +23,14 @@ export default function TestAnim({
     scale: number,
     depth: number
 }) {
-    const PKM_INDEX = "0019"
+    let PKM_INDEX;
+    switch(animationKey){
+        case "ELECTRIC_SURGE": PKM_INDEX = "0025"; break;
+        case "PSYCHIC_SURGE": PKM_INDEX = "0063"; break;
+        case "GRASSY_SURGE": PKM_INDEX = "0069"; break;
+        case "MISTY_SURGE": PKM_INDEX = "0035"; break;
+        default: PKM_INDEX = "0019"; break;
+    }
     
     class TestAnimScene extends Phaser.Scene {
         preload() {


### PR DESCRIPTION
Change Ratata for other types for surge status that only apply to one type
![image](https://user-images.githubusercontent.com/566536/222809080-d50a8e94-3f91-4430-85d7-2da9583521da.png)
