### PR TITLE
reduce ditto rate to 0.5%

### DIFF
--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -2,7 +2,7 @@ import PokemonFactory from "./pokemon-factory"
 import { Pkm, PkmFamily } from "../types/enum/Pokemon"
 import Player from "./colyseus-models/player"
 import { IPokemon } from "../types"
-import { Probability } from "../types/Config"
+import { Probability, DITTO_RATE } from "../types/Config"
 import { Rarity } from "../types/enum/Game"
 import { pickRandomIn } from "../utils/random"
 import { clamp } from "../utils/number"
@@ -280,7 +280,7 @@ export default class Shop {
     for (let i = 0; i < 6; i++) {
       let pokemon = this.pickPokemon(player)
       const seed = Math.random()
-      if (seed > 0.99) {
+      if (seed < DITTO_RATE) {
         pokemon = Pkm.DITTO
       }
       player.shop[i] = pokemon

--- a/app/public/src/pages/component/wiki/wiki-faq.tsx
+++ b/app/public/src/pages/component/wiki/wiki-faq.tsx
@@ -84,8 +84,8 @@ export default class WikiFaq extends Component {
         <h4 className="nes-text is-success">How does Ditto work ?</h4>
         <p>
           Ditto creates a plain copy of the unit you hover and drop it over.
-          Ditto can't fight. Each pokemon in shop has a 1% chance to be a
-          ditto at every roll. You can't copy mythical pokemon.
+          Ditto can't fight. Each pokemon in shop has a 0.5% chance to be a
+          Ditto at every roll. You can't copy mythical pokemons.
         </p>
         <h4 className="nes-text is-success">How do the items work ?</h4>
         <p>

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -124,6 +124,8 @@ export const RarityProbability: { [key in Rarity]: number } = {
   [Rarity.HATCH]: 0.1
 }
 
+export const DITTO_RATE = 0.005
+
 export const AttackTypeColor: { [key in AttackType] } = {
   [AttackType.PHYSICAL]: "#FF6E55",
   [AttackType.SPECIAL]: "#7FC9FF",


### PR DESCRIPTION
Due to the change of poolsize for 2-stage merged here :https://github.com/keldaanInteractive/pokemonAutoChess/commit/7192631611f1dc6622d99f9d88660ef23f43a24d 

The odds of getting 3 stars is significantly higher (+27.5% for Rare category, which has the most of 2-stage mons)

To compensate this change and avoid having a meta focused on high reroll for T3, I suggest to change the ditto rate from 1% to 0.5%

discussed here: https://discord.com/channels/737230355039387749/1081660504247902360/1081719482273243247