### PR TITLE
nerf aqua egg

### DIFF
--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -299,9 +299,6 @@ export default class Simulation extends Schema implements ISimulation {
       pokemon.status.triggerSoulDew(2000)
     }
 
-    if (pokemon.items.has(Item.AQUA_EGG)) {
-      pokemon.setMana(pokemon.mana + pokemon.maxMana / 2)
-    }
     if (pokemon.items.has(Item.ZOOM_LENS)) {
       const spellPowerBoost = 5 * pokemon.baseAtk
       const atkBoost = 0.05 * pokemon.spellDamage

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -490,7 +490,7 @@ export const ItemStats: Record<Item, { [stat in Stat]?: number }> = {
   [Item.WATER_INCENSE]: { [Stat.SPELL_POWER]: 10, [Stat.SPE_DEF]: 1 },
   [Item.SHELL_BELL]: { [Stat.SPELL_POWER]: 10, [Stat.ATK]: 1 },
   [Item.LUCKY_EGG]: { [Stat.SPELL_POWER]: 10, [Stat.DEF]: 1 },
-  [Item.AQUA_EGG]: { [Stat.MANA]: 30 },
+  [Item.AQUA_EGG]: { [Stat.MANA]: 50 },
   [Item.BLUE_ORB]: { [Stat.MANA]: 15, [Stat.ATK_SPEED]: 10 },
   [Item.ZOOM_LENS]: { [Stat.MANA]: 15, [Stat.CRIT_CHANCE]: 5 },
   [Item.BRIGHT_POWDER]: { [Stat.MANA]: 15, [Stat.SHIELD]: 15 },

--- a/app/types/strings/Item.ts
+++ b/app/types/strings/Item.ts
@@ -89,7 +89,7 @@ export const ItemDescription: { [key in Item]: string } = Object.freeze({
   [Item.LUCKY_EGG]:
     "30% spell power for holder and adjacent allies in the same row",
   [Item.AQUA_EGG]:
-    "The holder gains 50% of its max mana + 30 mana when combat begins. After casting its ability the holder gains 20 mana",
+    "The holder gains +50 starting mana and regains 20 mana after casting its ability",
   [Item.BLUE_ORB]:
     "Every third attack from the holder unleashes a chain lightning that bounces to 2 enemies, burning 20 mana",
   [Item.ZOOM_LENS]:


### PR DESCRIPTION
as discussed here: https://discord.com/channels/737230355039387749/1081268405371412681

The item has been predominant in current meta for applying team-wide status effects or for Banette clones. Replacing the +50% max mana gain by a flat +50 Mana allows to delay the strongest abilities while preserving the identity of "spell spamming item"