### PR TITLE
change dark synergy levels to 3/6/9

### DIFF
--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -76,7 +76,7 @@ export const TypeTrigger: { [key in Synergy]: number[] } = {
   [Synergy.ELECTRIC]: [2, 4, 6],
   [Synergy.FIGHTING]: [2, 4, 6],
   [Synergy.PSYCHIC]: [2, 4, 6],
-  [Synergy.DARK]: [2, 4, 6],
+  [Synergy.DARK]: [3, 6, 9],
   [Synergy.METAL]: [2, 4],
   [Synergy.GROUND]: [2, 4, 6],
   [Synergy.POISON]: [3, 6],


### PR DESCRIPTION
looks like dark is the most problematic at the moment, hence the strong nerf as discussed here: https://discord.com/channels/737230355039387749/1082322913685930025