### PR TITLE
Fix drag/drops and reset drag state, 2nd try

### DIFF
--- a/app/public/src/pages/component/game/game-experience.tsx
+++ b/app/public/src/pages/component/game/game-experience.tsx
@@ -17,7 +17,7 @@ export default function GameExperience() {
       <span>Lvl {experienceManager.level}</span>
       <button
         className="bubbly orange buy-xp-button"
-        title="Buy 4 XP for 4 gold"
+        title="Buy 4 XP for 4 gold (shortcut: F)"
         onClick={() => { dispatch(levelClick()) }}
       >
         <Money value="Buy XP 4" />

--- a/app/public/src/pages/component/game/game-refresh.tsx
+++ b/app/public/src/pages/component/game/game-refresh.tsx
@@ -8,7 +8,7 @@ export default function GameRefresh() {
   return (
     <button
       className="bubbly blue refresh-button"
-      title="Refresh shop for 1 gold"
+      title="Refresh shop for 1 gold (shortcut: D)"
       onClick={() => {
         dispatch(refreshClick())
       }}

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -226,6 +226,9 @@ export class OnDragDropCommand extends Command<
               success = true
               message.updateBoard = false
             }
+          } else if(y === 0) {
+            this.room.swap(playerId, pokemon, x, y)
+            success = true
           }
         } else {
           if (y == 0 && pokemon.positionY == 0) {

--- a/changelog/patch-2.9.md
+++ b/changelog/patch-2.9.md
@@ -39,3 +39,7 @@ Abilities that were supposed to "deal damage in a line behind target" now work p
 Smoke status in renamed Paralysis, with a new visual effect
 Fixed Spike Armor ability
 Mindblown now does Special Damage and not True Damage
+Fix the bug that allows to sell a pokemon currently fighting
+Fix the position of pokemons dragged and dropped on the same spot
+Allow to move dittos on bench
+Add keyboard shortcut infos on tooltips

--- a/changelog/patch-2.9.md
+++ b/changelog/patch-2.9.md
@@ -22,16 +22,23 @@ Vulpix: Field → Psychic
 Seedot: no longer Field
 Mudkip: moved from Uncommon to Common								
 Chimchar: moved from Uncommon to Common
+Nerf stats: Aron, Lairon, Aggron, Swinub, Piloswine, Mamoswine, Golem
+Adjusted stats: Geodude, Graveler
 
 # Changes to Synergies
 
 Dark: synergy levels are now 3/6/9
 Baby: Hatch pokemons take 4 turns to auto-evolve
 
-# Changes to items
+# Changes to Items
 
 Rune protect now also protects from status alterations
 Flame Orb: the Wound status can no longer be synchronized by Mew ; clarified item description
+
+# Changes to Stages
+
+Stage 5: Pick 1 additional Common or Uncommon Pokemon out of 3 propositions
+Stage 8: Pick 1 additional Epic or Rare Pokemon out of 3 propositions
 
 # Misc
 


### PR DESCRIPTION
Le probleme venait de la variable pokemonHovered utilisée à la fois pour le survol et le drag. J'ai séparé en 2 variables distinctes et testé dans tous les sens possibles, je crois que cette fois c'est bon !

- Fix the bug that allows to sell a pokemon currently fighting
- Fix the position of pokemons dragged and dropped on the same spot
- Allow to move dittos on bench
- Add keyboard shortcut infos on tooltips