### PR TITLE
mythical shops rework

### DIFF
--- a/app/core/simulation.ts
+++ b/app/core/simulation.ts
@@ -290,9 +290,11 @@ export default class Simulation extends Schema implements ISimulation {
     }
 
     pokemon.items.forEach((item) => {
-      Object.entries(ItemStats[item]!).forEach(([stat, value]) =>
-        this.applyStat(pokemon, stat as Stat, value)
-      )
+      if(ItemStats[item]){
+        Object.entries(ItemStats[item]).forEach(([stat, value]) =>
+          this.applyStat(pokemon, stat as Stat, value)
+        )
+      }
     })
 
     if (pokemon.skill === Ability.SYNCHRO) {

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1,5 +1,5 @@
 import { Command } from "@colyseus/command"
-import { ItemRecipe, PkmCost, NeutralStage } from "../../types/Config"
+import { ItemRecipe, NeutralStage } from "../../types/Config"
 import { Item, BasicItems } from "../../types/enum/Item"
 import { BattleResult } from "../../types/enum/Game"
 import Player from "../../models/colyseus-models/player"
@@ -28,6 +28,7 @@ import { Synergy } from "../../types/enum/Synergy"
 import { Pkm, PkmIndex } from "../../types/enum/Pokemon"
 import { Pokemon } from "../../models/colyseus-models/pokemon"
 import { Ability } from "../../types/enum/Ability"
+import { Mythical1Shop, Mythical2Shop } from "../../models/shop"
 
 export class OnShopCommand extends Command<
   GameRoom,
@@ -1101,9 +1102,9 @@ export class OnUpdatePhaseCommand extends Command<GameRoom, any> {
         if (!player.isBot) {
           if (!player.shopLocked) {
             if (this.state.stageLevel == 10) {
-              this.state.shop.assignFirstMythicalShop(player)
+              this.state.shop.assignMythicalShop(player, Mythical1Shop)
             } else if (this.state.stageLevel == 20) {
-              this.state.shop.assignSecondMythicalShop(player)
+              this.state.shop.assignMythicalShop(player, Mythical2Shop)
             } else {
               this.state.shop.assignShop(player)
             }

--- a/app/utils/array.ts
+++ b/app/utils/array.ts
@@ -13,3 +13,7 @@ export function sum(arr: number[]): number {
 export function deduplicateArray<T>(arr: T[]): T[] {
   return arr.filter((item,index, array) => array.indexOf(item) === index)
 }
+
+export function removeInArray<T>(arr: T[], el: T) {
+  arr.splice(arr.indexOf(el), 1)
+}

--- a/changelog/patch-2.10.md
+++ b/changelog/patch-2.10.md
@@ -14,9 +14,11 @@
 - Kings Rock has been replaced by Amulet coin, the effect does not change
 - Water Incense replaced by Power Lens: 50% of received spell damage is reflected to the attacker
 - Bright Powder replaced by Star Dust: After casting ability, gain 50% of Max Mana as Shield
+- Buff Souldew
 
 # Changes to Stages
 
+- Mythical picks at stage 10 and 20 are less random, giving at least one choice that matches your top 2 synergies
 
 # Bugfix
 
@@ -27,4 +29,9 @@
 - Prevent pokemon tooltip from going out of screen
 
 # Misc
+
+- Add stacks counter info next to items that stacks
+- rename Mineral & Metal synergies to Rock & Steel
+
+
 


### PR DESCRIPTION
as discussed here: https://discord.com/channels/737230355039387749/1086308835221844018

in mythical shops, out of the 6 propositions:
- 1 will be guaranteed to have one synergy that matches your top 2 synergies of last round (elected based on the same rule than Kecleon/Arceus)
- 2 will be guaranteed to have one synergy in common with one pokemon on your board last round, be it an active synergy or not
- the last 3 will be completely random