### PR TITLE
put mythicals in propositions menu

### DIFF
--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -290,7 +290,7 @@ export default class Shop {
     }
   }
 
-  assignMythicalShop(player: Player, list: Pkm[]) {
+  assignMythicalPropositions(player: Player, list: Pkm[]) {
     const mythicals = [...list]
     const synergies = Array.from(player.synergies).filter(([synergy, value]) => value > 0).map(([synergy, value]) => synergy)
     const top2Synergies = Array.from(player.synergies).sort(([s1, v1], [s2, v2]) => v2 - v1).slice(0,2).map(([synergy, value]) => synergy)
@@ -323,9 +323,7 @@ export default class Shop {
     }
 
     shuffleArray(shop)
-    for (let i = 0; i < 6; i++) {
-      player.shop[i] = shop[i]
-    }
+    shop.forEach(pkm => player.pokemonsProposition.push(pkm))
   }
 
   getRandomPokemonFromPool(pool: Map<Pkm, number>, finals: Array<Pkm>): Pkm {

--- a/app/public/src/pages/component/game/game-item.tsx
+++ b/app/public/src/pages/component/game/game-item.tsx
@@ -6,7 +6,7 @@ import { itemClick } from "../../../stores/NetworkStore"
 import { addIconsToDescription } from "../../utils/descriptions"
 
 const style: CSS.Properties = {
-  width: "30%",
+  width: "320px",
   display: "flex",
   flexFlow: "column",
   alignItems: "center",

--- a/app/public/src/pages/component/game/game-items-proposition.tsx
+++ b/app/public/src/pages/component/game/game-items-proposition.tsx
@@ -6,8 +6,8 @@ import { useAppSelector } from "../../../hooks"
 const style: CSS.Properties = {
   position: "absolute",
   top: "30%",
-  left: "15.5%",
-  width: "60%"
+  left: "50%",
+  transform: "translateX(-50%)"
 }
 
 export default function GameItemsProposition() {
@@ -21,8 +21,8 @@ export default function GameItemsProposition() {
         <div
           style={{
             display: "flex",
-            justifyContent: "space-between",
-            padding: "10px",
+            gap: "1vw",
+            justifyContent: "center",
             visibility: visible ? 'visible' : 'hidden'
           }}
         >
@@ -31,7 +31,7 @@ export default function GameItemsProposition() {
           })}
         </div>
 
-        <div style={{ display: "flex", justifyContent: "center" }}>
+        <div style={{ display: "flex", justifyContent: "center", margin: "1em" }}>
           <button
             className="bubbly orange"
             onClick={() => {

--- a/app/public/src/pages/component/game/game-items-proposition.tsx
+++ b/app/public/src/pages/component/game/game-items-proposition.tsx
@@ -11,26 +11,25 @@ const style: CSS.Properties = {
 }
 
 export default function GameItemsProposition() {
-  const itemsProposition = useAppSelector(
-    (state) => state.game.itemsProposition
-  )
+  const itemsProposition = useAppSelector((state) => state.game.itemsProposition)
+  const pokemonsProposition = useAppSelector((state) => state.game.pokemonsProposition)
+
   const [visible, setVisible] = useState(true)
-  if (itemsProposition.length > 0) {
+  if (itemsProposition.length > 0 && pokemonsProposition.length === 0) {
     return (
       <div style={style}>
-        {visible ? (
-          <div
-            style={{
-              display: "flex",
-              justifyContent: "space-between",
-              padding: "10px"
-            }}
-          >
-            {itemsProposition.map((e, i) => {
-              return <GameItem key={i} item={e} />
-            })}
-          </div>
-        ) : null}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            padding: "10px",
+            visibility: visible ? 'visible' : 'hidden'
+          }}
+        >
+          {itemsProposition.map((e, i) => {
+            return <GameItem key={i} item={e} />
+          })}
+        </div>
 
         <div style={{ display: "flex", justifyContent: "center" }}>
           <button

--- a/app/public/src/pages/component/game/game-pokemons-proposition.tsx
+++ b/app/public/src/pages/component/game/game-pokemons-proposition.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useState } from "react"
 import CSS from "csstype"
 import { useAppDispatch, useAppSelector } from "../../../hooks"
 import GamePokemonPortrait from "./game-pokemon-portrait"
@@ -14,42 +14,54 @@ const style: CSS.Properties = {
 
 export default function GamePokemonsPropositions() {
   const dispatch = useAppDispatch()
-  const pokemonsProposition = useAppSelector(
-    (state) => state.game.pokemonsProposition
-  )
-  const pokemonCollection = useAppSelector(
-    (state) => state.game.pokemonCollection
-  )
+  const pokemonsProposition = useAppSelector((state) => state.game.pokemonsProposition)
+  const pokemonCollection = useAppSelector((state) => state.game.pokemonCollection)
+  const stageLevel =  useAppSelector((state) => state.game.stageLevel)
+
+  const [visible, setVisible] = useState(true)
   if (pokemonsProposition.length > 0) {
     return (
-      <div style={style} className="nes-container">
-        <h2 style={{ textAlign: "center" }}>
-          Pick an additional Pokemon. It will be available to everyone.
-        </h2>
-        <div
-          style={{
-            display: "flex",
-            padding: "10px",
-            gap: "1vw",
-            height: "17vh",
-            justifyContent: "center"
-          }}
-        >
-          {pokemonsProposition.map((pokemon, index) => {
-            const p = PokemonFactory.createPokemonFromName(pokemon)
-            return (
-              <GamePokemonPortrait
-                key={'proposition'+index}
-                origin="proposition"
-                index={index}
-                pokemon={p}
-                pokemonConfig={pokemonCollection.get(p.index)}
-                click={(e) => {
-                  dispatch(pokemonPropositionClick(p.name))
-                }}
-              />
-            )
-          })}
+      <div style={style}>
+        <div className="nes-container" style={{visibility: visible ? 'visible' : 'hidden'}}>
+          {(stageLevel === 5 || stageLevel === 8) && (<h2 style={{ textAlign: "center" }}>
+            Pick an additional Pokemon. It will be available to everyone.
+          </h2>)}
+          <div
+            style={{
+              display: "flex",
+              padding: "10px",
+              gap: "1vw",
+              height: "17vh",
+              justifyContent: "center"
+            }}
+          >
+            {pokemonsProposition.map((pokemon, index) => {
+              const p = PokemonFactory.createPokemonFromName(pokemon)
+              return (
+                <GamePokemonPortrait
+                  key={'proposition'+index}
+                  origin="proposition"
+                  index={index}
+                  pokemon={p}
+                  pokemonConfig={pokemonCollection.get(p.index)}
+                  click={(e) => {
+                    dispatch(pokemonPropositionClick(p.name))
+                  }}
+                />
+              )
+            })}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", justifyContent: "center" }}>
+          <button
+            className="bubbly orange"
+            onClick={() => {
+              setVisible(!visible)
+            }}
+          >
+            {visible ? "Hide" : "Show"}
+          </button>
         </div>
       </div>
     )

--- a/app/public/src/pages/component/game/game-pokemons-proposition.tsx
+++ b/app/public/src/pages/component/game/game-pokemons-proposition.tsx
@@ -8,8 +8,8 @@ import { pokemonPropositionClick } from "../../../stores/NetworkStore"
 const style: CSS.Properties = {
   position: "absolute",
   top: "30%",
-  left: "20.5%",
-  width: "60%"
+  left: "50%",
+  transform: "translateX(-50%)"
 }
 
 export default function GamePokemonsPropositions() {
@@ -31,7 +31,6 @@ export default function GamePokemonsPropositions() {
               display: "flex",
               padding: "10px",
               gap: "1vw",
-              height: "17vh",
               justifyContent: "center"
             }}
           >
@@ -53,7 +52,7 @@ export default function GamePokemonsPropositions() {
           </div>
         </div>
 
-        <div style={{ display: "flex", justifyContent: "center" }}>
+        <div style={{ display: "flex", justifyContent: "center", margin: "1em" }}>
           <button
             className="bubbly orange"
             onClick={() => {

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -105,8 +105,10 @@ export class OnPokemonPropositionCommand extends Command<
   execute({ playerId, pkm }) {
     const player = this.state.players.get(playerId)
     if (player && !this.state.additionalPokemons.includes(pkm)) {
-      this.state.additionalPokemons.push(pkm)
-      this.state.shop.addAdditionalPokemon(pkm)
+      if (this.state.stageLevel === 5 || this.state.stageLevel === 8) {
+        this.state.additionalPokemons.push(pkm)
+        this.state.shop.addAdditionalPokemon(pkm)
+      }
       if (this.room.getBenchSize(player.board) < 8) {
         const pokemon = PokemonFactory.createPokemonFromName(
           pkm,
@@ -1069,13 +1071,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom, any> {
         player.opponentName = ""
         if (!player.isBot) {
           if (!player.shopLocked) {
-            if (this.state.stageLevel == 10) {
-              this.state.shop.assignMythicalShop(player, Mythical1Shop)
-            } else if (this.state.stageLevel == 20) {
-              this.state.shop.assignMythicalShop(player, Mythical2Shop)
-            } else {
-              this.state.shop.assignShop(player)
-            }
+            this.state.shop.assignShop(player)
           } else {
             player.shopLocked = false
           }
@@ -1152,6 +1148,18 @@ export class OnUpdatePhaseCommand extends Command<GameRoom, any> {
             }
           }
         }
+      })
+    }
+
+    if (this.state.stageLevel === 10) {
+      this.state.players.forEach((player: Player) => {
+        this.state.shop.assignMythicalPropositions(player, Mythical1Shop)  
+      })
+    }
+    
+    if (this.state.stageLevel === 20) {
+      this.state.players.forEach((player: Player) => {
+        this.state.shop.assignMythicalPropositions(player, Mythical2Shop)  
       })
     }
   }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/566536/227689549-d2c86c51-6640-42d1-b46d-0f129b6af9fa.png)

select mythicals the same way than additional picks

allows to prevent skipping mythicals pick when shop is locked

added show/hide button to pokemon picks