### PR TITLE
review carousel turns

### DIFF
--- a/app/core/matter/mini-game.ts
+++ b/app/core/matter/mini-game.ts
@@ -125,7 +125,7 @@ export class MiniGame {
     this.items = items
   }
 
-  initialize(players: MapSchema<Player>) {
+  initialize(players: MapSchema<Player>, stageLevel: number) {
     this.alivePlayers = new Array<Player>()
     players.forEach((p) => {
       if (p.alive) {
@@ -137,12 +137,17 @@ export class MiniGame {
         this.centerX + Math.cos((2 * Math.PI * i) / this.alivePlayers.length) * 300
       const y =
         this.centerY + Math.sin((2 * Math.PI * i) / this.alivePlayers.length) * 250
+      let retentionDelay = 4000 + (this.alivePlayers.length - player.rank) * 2000
+      if(stageLevel < 3){
+        retentionDelay = 5000
+      }
+
       const avatar = new PokemonAvatar(
         player.id,
         player.avatar,
         x,
         y,
-        4000 + (this.alivePlayers.length - player.rank) * 2000
+        retentionDelay
       )
 
       if(player.isBot){

--- a/app/models/colyseus-models/player.ts
+++ b/app/models/colyseus-models/player.ts
@@ -46,6 +46,7 @@ export default class Player extends Schema implements IPlayer {
   @type({ map: PokemonConfig }) pokemonCollection
   @type("string") title: Title | ""
   @type("string") role: Role
+  @type(["string"]) itemsProposition = new ArraySchema<Item>()
   @type(["string"]) pokemonsProposition = new ArraySchema<Pkm>()
   effects: Effects = new Effects()
   isBot: boolean

--- a/app/public/src/game/components/floating-item.ts
+++ b/app/public/src/game/components/floating-item.ts
@@ -27,13 +27,14 @@ export class FloatingItem extends GameObjects.Container {
   onGrab(playerId){
     const currentPlayerId: string = (this.scene as GameScene).uid!
     if(playerId === currentPlayerId){
-      this.circle.setStrokeStyle(2, 0x4CFF00, 0.85)
+      this.circle.setStrokeStyle(2, 0x4CFF00, 1)
+      this.circle.setFillStyle(0x61738a, 1)
     } else if(playerId == ""){
       this.circle.setStrokeStyle(1, 0xffffff, 0.7)
-      this.circle.setFillStyle(0x61738a, 1) 
+      this.circle.setFillStyle(0x61738a, 1)
     } else {
-      this.circle.setStrokeStyle(1, 0x7F0000, 0.7)
-      this.circle.setFillStyle(0x61738a, 0) 
+      this.circle.setStrokeStyle(2, 0xCF0000, 0.7)
+      this.circle.setFillStyle(0x61738a, 0.7) 
     }
   }
 }

--- a/app/public/src/game/components/pokemon.ts
+++ b/app/public/src/game/components/pokemon.ts
@@ -380,8 +380,8 @@ export default class Pokemon extends DraggableObject {
       this.circleTimer.clear()
       this.circleTimer.lineStyle(
         8,
-        this.isCurrentPlayerAvatar ? 0xff0000 : 0x7f0000,
-        0.75
+        0xF7D51D,
+        this.isCurrentPlayerAvatar ? 0.8 : 0.5
       )
       this.circleTimer.beginPath()
 

--- a/app/public/src/pages/component/game/game-item.tsx
+++ b/app/public/src/pages/component/game/game-item.tsx
@@ -1,0 +1,38 @@
+import React from "react"
+import { ItemName, ItemDescription } from "../../../../../types/strings/Item"
+import CSS from "csstype"
+import { useAppDispatch } from "../../../hooks"
+import { itemClick } from "../../../stores/NetworkStore"
+import { addIconsToDescription } from "../../utils/descriptions"
+
+const style: CSS.Properties = {
+  width: "320px",
+  display: "flex",
+  flexFlow: "column",
+  alignItems: "center",
+  justifyContent: "space-around",
+  textAlign: "center"
+}
+
+export default function GameItem(props: { item: string }) {
+  const dispatch = useAppDispatch()
+  return (
+    <div className="nes-container" style={style}>
+      <img
+        style={{ width: "96px", height: "96px", imageRendering: "pixelated" }}
+        src={"assets/item/" + props.item + ".png"}
+      ></img>
+      <h3>{ItemName[props.item]}</h3>
+      <p>{addIconsToDescription(ItemDescription[props.item])}</p>
+      <button
+        onClick={() => {
+          dispatch(itemClick(props.item))
+        }}
+        type="button"
+        className="bubbly blue"
+      >
+        Pick
+      </button>
+    </div>
+  )
+}

--- a/app/public/src/pages/component/game/game-items-proposition.tsx
+++ b/app/public/src/pages/component/game/game-items-proposition.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from "react"
+import GameItem from "./game-item"
+import CSS from "csstype"
+import { useAppSelector } from "../../../hooks"
+
+const style: CSS.Properties = {
+  position: "absolute",
+  top: "30%",
+  left: "50%",
+  transform: "translateX(-50%)"
+}
+
+export default function GameItemsProposition() {
+  const itemsProposition = useAppSelector((state) => state.game.itemsProposition)
+  const pokemonsProposition = useAppSelector((state) => state.game.pokemonsProposition)
+
+  const [visible, setVisible] = useState(true)
+  if (itemsProposition.length > 0 && pokemonsProposition.length === 0) {
+    return (
+      <div style={style}>
+        <div
+          style={{
+            display: "flex",
+            gap: "1vw",
+            justifyContent: "center",
+            visibility: visible ? 'visible' : 'hidden'
+          }}
+        >
+          {itemsProposition.map((e, i) => {
+            return <GameItem key={i} item={e} />
+          })}
+        </div>
+
+        <div style={{ display: "flex", justifyContent: "center", margin: "1em" }}>
+          <button
+            className="bubbly orange"
+            onClick={() => {
+              setVisible(!visible)
+            }}
+          >
+            {visible ? "Hide" : "Show"}
+          </button>
+        </div>
+      </div>
+    )
+  } else {
+    return null
+  }
+}

--- a/app/public/src/pages/game.tsx
+++ b/app/public/src/pages/game.tsx
@@ -11,6 +11,7 @@ import {
   setCurrentPlayerId,
   setExperienceManager,
   setInterest,
+  setItemsProposition,
   setMapName,
   setMoney,
   setPhase,
@@ -51,6 +52,7 @@ import { FIREBASE_CONFIG } from "./utils/utils"
 import GameContainer from "../game/game-container"
 import { Navigate } from "react-router-dom"
 import GameDpsMeter from "./component/game/game-dps-meter"
+import GameItemsProposition from "./component/game/game-items-proposition"
 import GamePlayerInformations from "./component/game/game-player-informations"
 import GamePlayers from "./component/game/game-players"
 import GameShop from "./component/game/game-shop"
@@ -369,6 +371,17 @@ export default function Game() {
           dispatch(setSynergies({ id: player.id, value: player.synergies }))
         }
 
+        player.itemsProposition.onAdd = (changes) => {
+          if (player.id == uid) {
+            dispatch(setItemsProposition(player.itemsProposition))
+          }
+        }
+        player.itemsProposition.onRemove = (changes) => {
+          if (player.id == uid) {
+            dispatch(setItemsProposition(player.itemsProposition))
+          }
+        }
+
         player.pokemonsProposition.onAdd = (changes) => {
           if (player.id == uid) {
             dispatch(setPokemonProposition(player.pokemonsProposition))
@@ -475,6 +488,7 @@ export default function Game() {
         <GamePlayerInformations />
         <GamePlayers click={(id: string) => playerClick(id)} />
         <GameSynergies />
+        <GameItemsProposition />
         <GamePokemonsProposition />
         <GameDpsMeter />
         <GameToasts />

--- a/app/public/src/stores/GameStore.ts
+++ b/app/public/src/stores/GameStore.ts
@@ -28,6 +28,7 @@ interface GameStateStore {
   shopLocked: boolean
   experienceManager: ExperienceManager
   shop: Pkm[]
+  itemsProposition: string[]
   pokemonsProposition: Pkm[]
   currentPlayerSynergies: [string, number][]
   currentPlayerOpponentName: string
@@ -62,6 +63,7 @@ const initialState: GameStateStore = {
   shopLocked: false,
   experienceManager: new ExperienceManager(),
   shop: new Array<Pkm>(),
+  itemsProposition: new Array<Item>(),
   pokemonsProposition: new Array<Pkm>(),
   currentPlayerSynergies: new Array<[Synergy, number]>(),
   currentPlayerOpponentName: "",
@@ -153,6 +155,9 @@ export const gameSlice = createSlice({
     },
     setShop: (state, action: PayloadAction<ArraySchema<Pkm>>) => {
       state.shop = action.payload
+    },
+    setItemsProposition: (state, action: PayloadAction<ArraySchema<Item>>) => {
+      state.itemsProposition = JSON.parse(JSON.stringify(action.payload))
     },
     setPokemonProposition: (state, action: PayloadAction<Pkm[]>) => {
       state.pokemonsProposition = JSON.parse(JSON.stringify(action.payload))
@@ -464,7 +469,8 @@ export const {
   setMoney,
   setShopLocked,
   changePlayer,
-  setShop
+  setShop,
+  setItemsProposition
 } = gameSlice.actions
 
 export default gameSlice.reducer

--- a/app/public/src/stores/NetworkStore.ts
+++ b/app/public/src/stores/NetworkStore.ts
@@ -148,6 +148,9 @@ export const networkSlice = createSlice({
     pokemonPropositionClick: (state, action: PayloadAction<Pkm>) => {
       state.game?.send(Transfer.POKEMON_PROPOSITION, action.payload)
     },
+    itemClick: (state, action: PayloadAction<string>) => {
+      state.game?.send(Transfer.ITEM, { id: action.payload })
+    },
     gameStart: (state, action: PayloadAction<string>) => {
       state.preparation?.send(Transfer.GAME_START, { id: action.payload })
     },
@@ -246,6 +249,7 @@ export const {
   removeBot,
   toggleReady,
   requestTilemap,
+  itemClick,
   shopClick,
   levelClick,
   lockClick,

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -9,6 +9,7 @@ import UserMetadata, {
 import BOT from "../models/mongo-models/bot-v2"
 import {
   OnShopCommand,
+  OnItemCommand,
   OnSellDropCommand,
   OnRefreshCommand,
   OnLockCommand,
@@ -123,6 +124,19 @@ export default class GameRoom extends Room<GameState> {
         //this.state.shop.assignShop(player)
       }
     }
+
+    this.onMessage(Transfer.ITEM, (client, message) => {
+      if (!this.state.gameFinished) {
+        try {
+          this.dispatcher.dispatch(new OnItemCommand(), {
+            playerId: client.auth.uid,
+            id: message.id
+          })
+        } catch (error) {
+          console.log(error)
+        }
+      }
+    })
 
     this.onMessage(Transfer.SHOP, (client, message) => {
       if (!this.state.gameFinished) {

--- a/app/types/Config.ts
+++ b/app/types/Config.ts
@@ -149,6 +149,9 @@ export const EvolutionTime = {
   EVOLVE_HATCH: 4
 }
 
+export const CarouselStages = [1, 6, 11, 16, 21, 26, 31]
+export const ItemProposalStages = [2, 3]
+
 export const NeutralStage: { turn: number; avatar: string }[] = [
   {
     turn: 1,

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -36,8 +36,6 @@ export * from "./enum/Emotion"
 
 export const FIGHTING_PHASE_DURATION = 40000
 
-export const MINIGAME_PHASE_DURATION = 40000
-
 export const CDN_PORTRAIT_URL =
   "https://raw.githubusercontent.com/keldaanInteractive/SpriteCollab/master/portrait/"
 
@@ -294,6 +292,7 @@ export interface IPlayer {
   pokemonCollection: PokemonCollection
   title: Title | ""
   role: Role
+  itemsProposition: Item[]
   pokemonsProposition: Pkm[]
   rerollCount: number
 }

--- a/changelog/patch-3.1.md
+++ b/changelog/patch-3.1.md
@@ -1,0 +1,27 @@
+# New Pokemons:
+
+
+
+# Changes to Pokemon
+
+
+# Changes to Synergies
+
+
+
+# Changes to Items
+
+Fixed Delta Orb applying the effect of Lucky Egg
+
+# Changes to Stages
+
+- Stage 1: all players now have the same retention delay for the carousel round
+- Stage 2 & 3: carousel rounds have been replaced by item choice rounds
+- Moved Carousel rounds to one round later after PVE: stage 6, 11, 16, 21, 26, 31
+- Carousel now have less items and less time depending on the number of players alive
+
+# Misc
+
+- Player avatars now can be shiny
+- Bots now take items in the carousel
+

--- a/changelog/patch-3.1.md
+++ b/changelog/patch-3.1.md
@@ -7,7 +7,7 @@
 
 # Changes to Synergies
 
-
+- Field: the heal effect is now triggered 16 milliseconds after one pokemon is KO, so that team is more vulnerable to Area of Effect damage
 
 # Changes to Items
 


### PR DESCRIPTION
discussed here: https://discord.com/channels/737230355039387749/1089946460809875487

During the first 3 carousel rounds, all players have 100HP, therefore their order of retention for the carousel is purely based on the order in the lobby, giving an unfair advantage to the player last in the list.

This PR changes the early-game stages:
- stage 1: carousel round, same retention delay for all players
- stage 2 & 3: 1 item choice out of 3 (i brought back item propositions window)
- stages 6, 11, 16, 21, 26, 31: carousels

Other changes:
- reduce carousel phase duration depending on the number of players alive
- stylistic changes to the carousel timers and visual feedback
- moved carousels after PVE so that items can be chosen depending on the random item from PVE or the mythical picked