### PR TITLE
less new room sounds

### DIFF
--- a/app/public/src/pages/lobby.tsx
+++ b/app/public/src/pages/lobby.tsx
@@ -60,7 +60,6 @@ import Booster from "./component/booster/booster"
 import { IPokemonsStatistic } from "../../../models/mongo-models/pokemons-statistic"
 import { cc } from "./utils/jsx"
 import "./lobby.css"
-import { playSound, SOUNDS } from "./utils/audio"
 
 export default function Lobby() {
   const dispatch = useAppDispatch()
@@ -195,7 +194,6 @@ export default function Lobby() {
             room.onMessage("+", ([roomId, room]) => {
               if (room.name === "room" || room.name === "game") {
                 dispatch(addRoom(room))
-                playSound(SOUNDS.NEW_ROOM)
               }
             })
 

--- a/app/public/src/stores/LobbyStore.ts
+++ b/app/public/src/stores/LobbyStore.ts
@@ -15,6 +15,7 @@ import { IPokemonConfig } from "../../../models/mongo-models/user-metadata"
 import PokemonConfig from "../../../models/colyseus-models/pokemon-config"
 import { Synergy } from "../../../types/enum/Synergy"
 import { IPokemonsStatistic } from "../../../models/mongo-models/pokemons-statistic"
+import { playSound, SOUNDS } from "../pages/utils/audio"
 
 interface IUserLobbyState {
   messages: IMessage[]
@@ -228,6 +229,9 @@ export const lobbySlice = createSlice({
         if (roomIndex !== -1) {
           rooms[roomIndex] = action.payload
         } else {
+          if(metadata.type === "preparation"){
+            playSound(SOUNDS.NEW_ROOM)
+          }
           rooms.push(action.payload)
         }
       }


### PR DESCRIPTION
the "new room" sound is triggered too often, every time a room in progress is fetched or updated. This PR changes the condition so it only play a sound when a new preparation room is added to the list.