### PR TITLE
Simplify synergy descriptions

### DIFF
--- a/app/core/attacking-state.ts
+++ b/app/core/attacking-state.ts
@@ -60,7 +60,7 @@ export default class AttackingState extends PokemonState {
         pokemon.strategy.process(pokemon, this, board, target)
       } else {
         // BASIC ATTACK
-        this.attack(pokemon, board, targetCoordinate, climate)
+        this.attack(pokemon, board, targetCoordinate)
         if (
           pokemon.effects.includes(Effect.EERIE_IMPULSE) ||
           pokemon.effects.includes(Effect.RISING_VOLTAGE) ||
@@ -76,8 +76,8 @@ export default class AttackingState extends PokemonState {
           }
           if (Math.random() < doubleAttackChance) {
             pokemon.count.doubleAttackCount++
-            this.attack(pokemon, board, targetCoordinate, climate)
-            this.attack(pokemon, board, targetCoordinate, climate)
+            this.attack(pokemon, board, targetCoordinate)
+            this.attack(pokemon, board, targetCoordinate)
           }
         }
       }
@@ -89,8 +89,7 @@ export default class AttackingState extends PokemonState {
   attack(
     pokemon: PokemonEntity,
     board: Board,
-    coordinates: { x: number; y: number },
-    climate: string
+    coordinates: { x: number; y: number }
   ) {
     pokemon.count.attackCount++
     pokemon.targetX = coordinates.x

--- a/app/core/moving-state.ts
+++ b/app/core/moving-state.ts
@@ -44,7 +44,7 @@ export default class MovingState extends PokemonState {
 
     let x: number | undefined = undefined
     let y: number | undefined = undefined
-    if (pokemon.types.includes(Synergy.DARK)) {
+    if (pokemon.types.includes(Synergy.DARK) && pokemon.baseRange === 1) {
       const farthestCoordinate = this.getFarthestTargetCoordinateAvailablePlace(
         pokemon,
         board

--- a/app/core/pokemon-entity.ts
+++ b/app/core/pokemon-entity.ts
@@ -64,6 +64,7 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
   baseAtk: number
   baseDef: number
   baseSpeDef: number
+  baseRange: number
   dodge: number
   physicalDamage: number
   specialDamage: number
@@ -105,6 +106,7 @@ export default class PokemonEntity extends Schema implements IPokemonEntity {
     this.baseAtk = pokemon.atk
     this.baseDef = pokemon.def
     this.baseSpeDef = pokemon.speDef
+    this.baseRange = pokemon.range
     this.atk = pokemon.atk
     this.def = pokemon.def
     this.speDef = pokemon.speDef

--- a/app/public/src/pages/component/icons/synergy-icon.css
+++ b/app/public/src/pages/component/icons/synergy-icon.css
@@ -3,4 +3,5 @@
   height: 40px;
   filter: drop-shadow(2px 2px 0px #505261);
   margin: 1px;
+  vertical-align: bottom;
 }

--- a/app/public/src/pages/component/synergy/effect-description.tsx
+++ b/app/public/src/pages/component/synergy/effect-description.tsx
@@ -4,10 +4,7 @@ import { EffectDescription } from "../../../../../types/strings/Effect"
 import { addIconsToDescription } from "../../utils/descriptions"
 import "./synergy-description.css"
 
-export const effectRegExp =
-  /PHYSICAL|SPECIAL|TRUE|atk|speed|critChance|critDamage|def|hp|mana|range|shield|speDef|ap/
-
-export function SynergyDescription(props: { effect: Effect }) {
+export function EffectDescriptionComponent(props: { effect: Effect }) {
   const description = EffectDescription[props.effect].eng
   return (
     <p className="synergy-description">{addIconsToDescription(description)}</p>

--- a/app/public/src/pages/component/synergy/synergy-detail-component.tsx
+++ b/app/public/src/pages/component/synergy/synergy-detail-component.tsx
@@ -4,7 +4,8 @@ import { PrecomputedTypePokemon } from "../../../../../types"
 import { Synergy } from "../../../../../types/enum/Synergy"
 import {
   SynergyName,
-  SynergyDetail
+  SynergyDetail,
+  SynergyDescription
 } from "../../../../../types/strings/Synergy"
 import PRECOMPUTED_TYPE_POKEMONS from "../../../../../models/precomputed/type-pokemons.json"
 import { Pkm } from "../../../../../types/enum/Pokemon"
@@ -13,7 +14,8 @@ import { TypeTrigger, RarityColor } from "../../../../../types/Config"
 import { useAppSelector } from "../../../hooks"
 import { getPortraitSrc } from "../../../utils"
 import SynergyIcon from "../icons/synergy-icon"
-import { SynergyDescription } from "./synergy-description"
+import { EffectDescriptionComponent } from "./effect-description"
+import { addIconsToDescription } from "../../utils/descriptions"
 
 const precomputed = PRECOMPUTED_TYPE_POKEMONS as PrecomputedTypePokemon
 
@@ -30,6 +32,7 @@ export default function SynergyDetailComponent(props: {
         <SynergyIcon type={props.type} size="40px" />
         <h3>{SynergyName[props.type].eng}</h3>
       </div>
+      <p>{addIconsToDescription(SynergyDescription[props.type].eng)}</p>
 
       {SynergyDetail[props.type].map((d, i) => {
         return (
@@ -53,7 +56,7 @@ export default function SynergyDetailComponent(props: {
             <h5 style={{ fontSize: "1.3vw" }}>
               ({TypeTrigger[props.type][i]}) {EffectName[d]}
             </h5>
-            <SynergyDescription effect={d} />
+            <EffectDescriptionComponent effect={d} />
           </div>
         )
       })}

--- a/app/public/src/pages/component/wiki/wiki-type.tsx
+++ b/app/public/src/pages/component/wiki/wiki-type.tsx
@@ -3,7 +3,8 @@ import ReactTooltip from "react-tooltip";
 import PRECOMPUTED_TYPE_POKEMONS_ALL from "../../../../../models/precomputed/type-pokemons-all.json"
 import {
   SynergyName,
-  SynergyDetail
+  SynergyDetail,
+  SynergyDescription
 } from "../../../../../types/strings/Synergy"
 import { EffectName } from "../../../../../types/strings/Effect"
 import { TypeTrigger, RarityColor } from "../../../../../types/Config"
@@ -11,12 +12,13 @@ import { Synergy } from "../../../../../types/enum/Synergy"
 import { Pkm, PkmFamily } from "../../../../../types/enum/Pokemon"
 import { getPortraitSrc } from "../../../utils"
 import SynergyIcon from "../icons/synergy-icon"
-import { SynergyDescription } from "../synergy/synergy-description"
+import { EffectDescriptionComponent } from "../synergy/effect-description"
 import { GamePokemonDetail } from "../game/game-pokemon-detail"
 import PokemonFactory from "../../../../../models/pokemon-factory";
 import { groupBy, deduplicateArray } from "../../../../../utils/array";
 import { Pokemon } from "../../../../../models/colyseus-models/pokemon";
 import { Rarity } from "../../../../../types/enum/Game";
+import { addIconsToDescription } from "../../utils/descriptions";
 
 export default function WikiType(props: { type: Synergy | "all" }) {
   const [hoveredPokemon, setHoveredPokemon] = useState<Pokemon>();
@@ -41,17 +43,15 @@ export default function WikiType(props: { type: Synergy | "all" }) {
   return (
     <div style={{padding: "1em"}}>
       {props.type !== "all" && (<>
-        <div style={{ display: "flex", marginBottom: "0.5em" }}>
-          <SynergyIcon type={props.type} />
-          <p>{SynergyName[props.type].eng}</p>
-        </div>
+        <h2><SynergyIcon type={props.type} /> {SynergyName[props.type].eng}</h2>
+        <p>{addIconsToDescription(SynergyDescription[props.type].eng)}</p>
         {SynergyDetail[props.type].map((effect, i) => {
           return (
             <div key={EffectName[effect]} style={{ display: "flex" }}>
               <p>
                 ({TypeTrigger[props.type][i]}) {EffectName[effect]}:&nbsp;
               </p>
-              <SynergyDescription effect={effect} />
+              <EffectDescriptionComponent effect={effect} />
             </div>
           )
         })}

--- a/app/types/strings/Effect.ts
+++ b/app/types/strings/Effect.ts
@@ -89,403 +89,403 @@ export const EffectDescription: {
   [key in Effect]: { eng: string; esp: string; fra: string }
 } = {
   [Effect.STAMINA]: {
-    eng: `All allies adjacent to your Normal pokemon have +20 ${Stat.SHIELD}`,
-    esp: `+20 HP por cada pokemon que esté cerca`,
-    fra: `+20 HP pour tous les pokémons autours`
+    eng: `Gain 20 ${Stat.SHIELD}`,
+    esp: `20 ${Stat.SHIELD}`,
+    fra: `20 ${Stat.SHIELD}`
   },
   [Effect.STRENGTH]: {
-    eng: `All allies adjacent to your Normal pokemon have +40 ${Stat.SHIELD}`,
-    esp: `+30 HP por cada pokemon que esté cerca`,
-    fra: `+30 HP pour tous les pokémons autours`
+    eng: `Gain 40 ${Stat.SHIELD}`,
+    esp: `40 ${Stat.SHIELD}`,
+    fra: `40 ${Stat.SHIELD}`
   },
   [Effect.ROCK_SMASH]: {
-    eng: `All allies adjacent to your Normal pokemon have +60 ${Stat.SHIELD}`,
-    esp: `+50 HP por cada pokemon que esté cerca`,
-    fra: `+50 HP pour tous les pokémons autours`
+    eng: `Gain 60 ${Stat.SHIELD}`,
+    esp: `60 ${Stat.SHIELD}`,
+    fra: `60 ${Stat.SHIELD}`
   },
   [Effect.PURE_POWER]: {
-    eng: `All allies adjacent to your Normal pokemon have +80 ${Stat.SHIELD}`,
-    esp: `+50 HP por cada pokemon que esté cerca`,
-    fra: `+50 HP pour tous les pokémons autours`
+    eng: `Gain 80 ${Stat.SHIELD}`,
+    esp: `80 ${Stat.SHIELD}`,
+    fra: `80 ${Stat.SHIELD}`
   },
   [Effect.INGRAIN]: {
-    eng: `Grass allies restore 5 ${Stat.HP} per second`,
-    esp: `+5% HP/s para los tipos de Planta`,
-    fra: `+5% HP/s pour tous les alliés plante`
+    eng: `Restore 5 ${Stat.HP} per second`,
+    esp: ``,
+    fra: ``
   },
   [Effect.GROWTH]: {
-    eng: `Grass allies restore 12 ${Stat.HP} per second`,
-    esp: `+10% HP/s para los tipos de Planta`,
-    fra: `+10% HP/s pour tous les alliés plante`
+    eng: `Restore 12 ${Stat.HP} per second`,
+    esp: ``,
+    fra: ``
   },
   [Effect.SPORE]: {
-    eng: `Grass allies restore 20 ${Stat.HP} per second`,
-    esp: `Los ennemigos que no son de Planta tienen un 30% ATK speed`,
-    fra: `-30% ATK speed pour tous les ennemis`
+    eng: `Restore 20 ${Stat.HP} per second`,
+    esp: ``,
+    fra: ``
   },
   [Effect.BLAZE]: {
-    eng: `Your Fire pokemon have 20% chance to ${Status.BURN} enemy for 2s`,
-    esp: `Fire pkm gana un 5% de dano en cada ataque`,
-    fra: `Les pkm feu gagnent 5% d'ATK à chaque attaque`
+    eng: `20% chance to ${Status.BURN}`,
+    esp: ``,
+    fra: ``
   },
   [Effect.VICTORY_STAR]: {
-    eng: `Your Fire pokemon have 20% chance to ${Status.BURN} enemy for 2s and gain +1 ${Stat.ATK} after every hit (Weather: Sunlight)`,
-    esp: `Fire pkm gana un 5% de dano en cada ataque`,
-    fra: `Les pkm feu gagnent 5% d'ATK à chaque attaque`
+    eng: `20% chance to ${Status.BURN}, +1 ${Stat.ATK} after every hit (Weather: Sunlight)`,
+    esp: ``,
+    fra: ``
   },
   [Effect.DROUGHT]: {
-    eng: `Your Fire pokemon have 30% chance to ${Status.BURN} enemy for 2s and gain +2 ${Stat.ATK} after every hit (Weather: Sunlight)`,
-    esp: `El so se intensifica, los pkm de fuego gana +50% ATK`,
-    fra: `Le soleil s'intensifie, augmentant l'ATK des pkm feu de 50%`
+    eng: `30% chance to ${Status.BURN}, +2 ${Stat.ATK} after every hit (Weather: Sunlight)`,
+    esp: ``,
+    fra: ``
   },
   [Effect.DESOLATE_LAND]: {
-    eng: `Your Fire pokemon have 40% chance to ${Status.BURN} enemy for 2s and gain +3 ${Stat.ATK} after every hit (Weather: Sunlight)`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+    eng: `40% chance to ${Status.BURN}, +3 ${Stat.ATK} after every hit (Weather: Sunlight)`,
+    esp: ``,
+    fra: ``
   },
   [Effect.RAIN_DANCE]: {
-    eng: `Water pokemons gain 25% chance to dodge enemy attacks (Weather: Rainy)`,
-    esp: `Cae la lluvia, 30% de ATK para los aliados del agua`,
-    fra: `La pluie tombe, 30% d'ATK pour les alliés eau`
+    eng: `25% chance to dodge (Weather: Rainy)`,
+    esp: ``,
+    fra: ``
   },
   [Effect.DRIZZLE]: {
-    eng: `Water pokemons gain 50% chance to dodge enemy attacks (Weather: Rainy)`,
-    esp: `La lluvia es cada vez más intensa, un 30% más de ATK.`,
-    fra: `La pluie s'intensifie, 30% d'ATK en plus`
+    eng: `50% chance to dodge (Weather: Rainy)`,
+    esp: ``,
+    fra: ``
   },
   [Effect.PRIMORDIAL_SEA]: {
-    eng: `Water pokemons gain 75% chance to dodge enemy attacks (Weather: Rainy)`,
-    esp: `Invoca a Kyogre, el rey de los océanos`,
-    fra: `Invoque Kyogre, le roi des océans`
+    eng: `75% chance to dodge (Weather: Rainy)`,
+    esp: ``,
+    fra: ``
   },
   [Effect.EERIE_IMPULSE]: {
-    eng: `Electric' Basic Attacks have a 30% chance to trigger two additional attacks against their target.`,
-    esp: `+10% de velocidad ATK por cada aliado eléctrico del equipo`,
-    fra: `+10% ATK speed pour chaque allié elec dans l'équipe`
+    eng: `30% chance of triple attack`,
+    esp: ``,
+    fra: ``
   },
   [Effect.RISING_VOLTAGE]: {
-    eng: `Electric' Basic Attacks have a 50% chance to trigger two additional attacks against their target.`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+    eng: `50% chance of triple attack`,
+    esp: ``,
+    fra: ``
   },
   [Effect.OVERDRIVE]: {
-    eng: `Electric' Basic Attacks have a 70% chance to trigger two additional attacks against their target.`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+    eng: `70% chance of triple attack`,
+    esp: ``,
+    fra: ``
   },
   [Effect.GUTS]: {
-    eng: `Fighting pokemons blocks 4 damage`,
-    esp: `+5 maná/ataque para todos los pkm`,
-    fra: `+5 mana / attaque pour tous les pkm`
+    eng: `Blocks 4 damage`,
+    esp: ``,
+    fra: ``
   },
   [Effect.DEFIANT]: {
-    eng: `Fighting pokemons blocks 7 damage`,
-    esp: `+10 maná/ataque para todos los pkm`,
-    fra: `+10 mana / attaque pour tous les pkm`
+    eng: `Blocks 7 damage`,
+    esp: ``,
+    fra: ``
   },
   [Effect.JUSTIFIED]: {
-    eng: `Fighting pokemons blocks 10 damage`,
-    esp: `+10 maná/ataque para todos los pkm`,
-    fra: `+10 mana / attaque pour tous les pkm`
+    eng: `Blocks 10 damage`,
+    esp: ``,
+    fra: ``
   },
   [Effect.AMNESIA]: {
-    eng: `Psychic pokemons gains +50% ${Stat.AP}`,
-    esp: `Ally gana +5 SPEDEF`,
-    fra: `Les alliés gagnent +5 SPEDEF`
+    eng: `+50% ${Stat.AP}`,
+    esp: ``,
+    fra: ``
   },
   [Effect.LIGHT_SCREEN]: {
-    eng: `Psychic pokemons gains +100% ${Stat.AP}`,
-    esp: `Ally gana +10 SPEDEF adicionales`,
-    fra: `Les alliés gagnent un additionel +10 SPEDEF`
+    eng: `+100% ${Stat.AP}`,
+    esp: ``,
+    fra: ``
   },
   [Effect.EERIE_SPELL]: {
-    eng: `Psychic pokemons gains +150% ${Stat.AP}`,
-    esp: `Ally gana +20 SPEDEF adicionales`,
-    fra: `Les alliés gagnent un additionel +20 SPEDEF`
-  },
-  [Effect.DUBIOUS_DISC]: {
-    eng: `Artificial pokemons gains +4 ${Stat.ATK}/+20 ${Stat.SHIELD} for each held items`,
-    esp: `Artificial pokemons gains +4 ${Stat.ATK}/+20 ${Stat.SHIELD} for each held items`,
-    fra: `Artificial pokemons gains +4 ${Stat.ATK}/+20 ${Stat.SHIELD} for each held items`
-  },
-  [Effect.LINK_CABLE]: {
-    eng: `Artificial pokemons gains +7 ${Stat.ATK}/+30 ${Stat.SHIELD} for each held items`,
-    esp: `Artificial pokemons gains +7 ${Stat.ATK}/+30 ${Stat.SHIELD} for each held items`,
-    fra: `Artificial pokemons gains +7 ${Stat.ATK}/+30 ${Stat.SHIELD} for each held items`
-  },
-  [Effect.GOOGLE_SPECS]: {
-    eng: `Artificial pokemons gains +10 ${Stat.ATK}/+50 ${Stat.SHIELD} for each held items`,
-    esp: `Artificial pokemons gains +10 ${Stat.ATK}/+50 ${Stat.SHIELD} for each held items`,
-    fra: `Artificial pokemons gains +10 ${Stat.ATK}/+50 ${Stat.SHIELD} for each held items`
-  },
-  [Effect.IRON_DEFENSE]: {
-    eng: `One of your steel Pokemon gains double base ${Stat.ATK}`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.AUTOTOMIZE]: {
-    eng: `All of your steel Pokemon gains double base ${Stat.ATK}`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.SHORE_UP]: {
-    eng: `Every 3 seconds, all ground pokemons gains 1 ${Stat.DEF}/${Stat.SPE_DEF} and 1 ${Stat.ATK} bonus stats, up to 4 times`,
+    eng: `+150% ${Stat.AP}`,
     esp: ``,
     fra: ``
-  },
-  [Effect.ROTOTILLER]: {
-    eng: `Every 3 seconds, all ground pokemons gains 2 ${Stat.DEF}/${Stat.SPE_DEF} and 2 ${Stat.ATK} bonus stats, up to 4 times`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.SANDSTORM]: {
-    eng: `Every 3 seconds, all ground pokemons gains 3 ${Stat.DEF}/${Stat.SPE_DEF} and 3 ${Stat.ATK} bonus stats, up to 4 times (Weather: Sandstorm)`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.POISON_GAS]: {
-    eng: `Your Poison pokemon have a 30% chance to ${Status.POISON} the target for 4 seconds.`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.TOXIC]: {
-    eng: `Your Poison pokemon have 70% chance to ${Status.POISON} the target for 4 seconds.`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.DRAGON_ENERGY]: {
-    eng: `Your Dragon pokemon gain +5% ${Stat.ATK_SPEED} after every hit.`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.DRAGON_DANCE]: {
-    eng: `Your Dragon pokemon gain +10%  ${Stat.ATK_SPEED} after every hit.`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.BULK_UP]: {
-    eng: `When a field pokemon dies, all other field pokemons gain 15% ${Stat.ATK_SPEED} and are healed for 20% ${Stat.HP} of their Maximum Health`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.RAGE]: {
-    eng: `When a field pokemon dies, all other field pokemons gain 20% ${Stat.ATK_SPEED} and are healed for 30% ${Stat.HP} of their Maximum Health`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.ANGER_POINT]: {
-    eng: `When a field pokemon dies, all other field pokemons gain 30% ${Stat.ATK_SPEED} and are healed for 40% ${Stat.HP} of their Maximum Health`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.PURSUIT]: {
-    eng: `Upon kill, grants 2 ${Stat.DEF}, 2 ${Stat.SPE_DEF}, 3 ${Stat.ATK} and heal 30 ${Stat.HP}`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.BRUTAL_SWING]: {
-    eng: `Upon kill, grants 4 ${Stat.DEF}, 4 ${Stat.SPE_DEF}, 6 ${Stat.ATK} and heal 60 ${Stat.HP}`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.POWER_TRIP]: {
-    eng: `Upon kill, grants 6 ${Stat.DEF}, 6 ${Stat.SPE_DEF}, 12 ${Stat.ATK} and heal 120 ${Stat.HP}`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.MEDITATE]: {
-    eng: `All allies heals for 15% ${Stat.HP} of the damage they deal with spells and attacks`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.FOCUS_ENERGY]: {
-    eng: `All allies heals for 30% ${Stat.HP} of the damage they deal with spells and attacks`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.CALM_MIND]: {
-    eng: `All allies heals for 60% ${Stat.HP} of the damage they deal with spells and attacks`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.ANCIENT_POWER]: {
-    eng: `Revive Fossil pokemons at first death with 40% ${Stat.HP} and 30% increased ${Stat.ATK}`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.ELDER_POWER]: {
-    eng: `Revive Fossil pokemons at first death with 80% ${Stat.HP} and 60% increased ${Stat.ATK}.`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.INFESTATION]: {
-    eng: `At the start of combat, creates a copy of a bug pokemon (ranked by ${Stat.HP})`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.HORDE]: {
-    eng: `At the start of combat, creates a copy of two bug pokemons (ranked by ${Stat.HP})`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.HEART_OF_THE_SWARM]: {
-    eng: `At the start of combat, creates a copy of four bug pokemons (ranked by ${Stat.HP})`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.TAILWIND]: {
-    eng: `Give ${Status.PROTECT} for 1 sec when the pokemon fell under 20% ${Stat.HP}`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.FEATHER_DANCE]: {
-    eng: `Give ${Status.PROTECT} for 1.5 sec when the pokemon fell under 40% ${Stat.HP}`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.MAX_AIRSTREAM]: {
-    eng: `Give ${Status.PROTECT} for 2 sec when the pokemon fell under 50% ${Stat.HP}`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.MAX_GUARD]: {
-    eng: `Give ${Status.PROTECT} for 2.5sec when the pokemon fell under 50% ${Stat.HP}`,
-    esp: ``,
-    fra: ``
-  },
-  [Effect.ODD_FLOWER]: {
-    eng: `When the first flora pokemon is dead, the odd flower will rise from its grave..`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.GLOOM_FLOWER]: {
-    eng: `When the first flora pokemon is dead, the gloom flower will rise from its grave..`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.VILE_FLOWER]: {
-    eng: `When the first flora pokemon is dead, the vile flower will rise from its grave..`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.SUN_FLOWER]: {
-    eng: `When the first flora pokemon is dead, the sun flower will rise from its grave..`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.BATTLE_ARMOR]: {
-    eng: `Rock pokemons gains 50 ${Stat.SHIELD} at the start of the combat`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.MOUTAIN_RESISTANCE]: {
-    eng: `Rock pokemons gains 100 ${Stat.SHIELD} at the start of the combat`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.DIAMOND_STORM]: {
-    eng: `Rock pokemons gains 200 ${Stat.SHIELD} at the start of the combat`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.PHANTOM_FORCE]: {
-    eng: `Your ghosts deal 20% of ${Stat.ATK} as ${Damage.TRUE} + 50% chance to ${Status.SILENCE} on hit`,
-    esp: `Los fantasmas ganan un 15% de velocidad ATK y hacen daño verdadero`,
-    fra: `Les fantômes gagnent 15% d'ATK speed et font des dégats bruts`
-  },
-  [Effect.CURSE]: {
-    eng: `Your ghosts deal 40% of ${Stat.ATK} as ${Damage.TRUE} + 50% chance to ${Status.SILENCE} on hit`,
-    esp: `Los ataques fantasma silencian sus objetivos`,
-    fra: `Les attaques des fantomes réduisent aux silences leurs cibles`
-  },
-  [Effect.SHADOW_TAG]: {
-    eng: `Your ghosts deal 70% of ${Stat.ATK} as ${Damage.TRUE} + 50% chance to ${Status.SILENCE} on hit`,
-    esp: `Los ataques fantasma silencian sus objetivos`,
-    fra: `Les attaques des fantomes réduisent aux silences leurs cibles`
-  },
-  [Effect.WANDERING_SPIRIT]: {
-    eng: `Yours ghost deals 100% of ${Stat.ATK} as ${Damage.TRUE} + 50% chance to ${Status.SILENCE} on hit`,
-    esp: `Los ataques fantasma silencian sus objetivos`,
-    fra: `Les attaques des fantomes réduisent aux silences leurs cibles`
-  },
-  [Effect.AROMATIC_MIST]: {
-    eng: `Fairy pokemons shock nearby enemies for 10 ${Damage.SPECIAL} whenever they deal or receive a critical strike`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.FAIRY_WIND]: {
-    eng: `Fairy pokemons shock nearby enemies for 30 ${Damage.SPECIAL} whenever they deal or receive a critical strike`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.STRANGE_STEAM]: {
-    eng: `Fairy pokemons shock nearby enemies for 60 ${Damage.SPECIAL} whenever they deal or receive a critical strike`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
-  },
-  [Effect.SNOW]: {
-    eng: `All allies have a 10% chance to ${Status.FREEZE} an enemy for 2 seconds after a hit (Weather: Snow)`,
-    esp: `+10% de probabilidad de congelar al enemigo durante un ataque`,
-    fra: `+10% de chance de geler l'ennemi lors d'une attaque`
-  },
-  [Effect.SHEER_COLD]: {
-    eng: `All allies pokemon have a 30% chance to ${Status.FREEZE} an enemy for 2 seconds after a hit (Weather: Snow)`,
-    esp: `+30% de probabilidad de congelar al enemigo durante un ataque`,
-    fra: `+30% de chance de geler l'ennemi lors d'une attaque`
   },
   [Effect.HONE_CLAWS]: {
-    eng: `Dark pokemons jump in the backline when combat starts and gain +40% ${Stat.CRIT_CHANCE} and +25% ${Stat.CRIT_DAMAGE}`,
+    eng: `Gain +40% ${Stat.CRIT_CHANCE} and +25% ${Stat.CRIT_DAMAGE}`,
     esp: ``,
     fra: ``
   },
   [Effect.ASSURANCE]: {
-    eng: `Dark pokemons jump in the backline when combat starts and gain  +60% ${Stat.CRIT_CHANCE} and +50% ${Stat.CRIT_DAMAGE}`,
+    eng: `Gain +60% ${Stat.CRIT_CHANCE} and +50% ${Stat.CRIT_DAMAGE}`,
     esp: ``,
     fra: ``
   },
   [Effect.BEAT_UP]: {
-    eng: `Dark pokemons jump in the backline when combat starts and gain +80% ${Stat.CRIT_CHANCE} and +75% ${Stat.CRIT_DAMAGE}`,
+    eng: `Gain +80% ${Stat.CRIT_CHANCE} and +75% ${Stat.CRIT_DAMAGE}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.IRON_DEFENSE]: {
+    eng: `One of your steel Pokemon gains double base ${Stat.ATK}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.AUTOTOMIZE]: {
+    eng: `All of your steel Pokemon gains double base ${Stat.ATK}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.SHORE_UP]: {
+    eng: `Gain +1 ${Stat.ATK} / ${Stat.DEF} / ${Stat.SPE_DEF}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.ROTOTILLER]: {
+    eng: `Gain +2 ${Stat.ATK} / ${Stat.DEF} / ${Stat.SPE_DEF}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.SANDSTORM]: {
+    eng: `Gain +3  ${Stat.ATK} / ${Stat.DEF} / ${Stat.SPE_DEF} (Weather: Sandstorm)`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.POISON_GAS]: {
+    eng: `30% chance to ${Status.POISON}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.TOXIC]: {
+    eng: `70% chance to ${Status.POISON}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.DRAGON_ENERGY]: {
+    eng: `Gain +5% ${Stat.ATK_SPEED}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.DRAGON_DANCE]: {
+    eng: `Gain +10%  ${Stat.ATK_SPEED}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.BULK_UP]: {
+    eng: `Gain 15% ${Stat.ATK_SPEED} and heal for 20% of max ${Stat.HP}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.RAGE]: {
+    eng: `Gain 20% ${Stat.ATK_SPEED} and heal for 30% of max ${Stat.HP}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.ANGER_POINT]: {
+    eng: `Gain 30% ${Stat.ATK_SPEED} and heal for 40% of max ${Stat.HP}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.PURSUIT]: {
+    eng: `Upon kill, grants 2 ${Stat.DEF}, 2 ${Stat.SPE_DEF}, 3 ${Stat.ATK} and heal 30 ${Stat.HP}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.BRUTAL_SWING]: {
+    eng: `Upon kill, grants 4 ${Stat.DEF}, 4 ${Stat.SPE_DEF}, 6 ${Stat.ATK} and heal 60 ${Stat.HP}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.POWER_TRIP]: {
+    eng: `Upon kill, grants 6 ${Stat.DEF}, 6 ${Stat.SPE_DEF}, 12 ${Stat.ATK} and heal 120 ${Stat.HP}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.MEDITATE]: {
+    eng: `Heal for 15% ${Stat.HP} of the damage`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.FOCUS_ENERGY]: {
+    eng: `Heal for 30% ${Stat.HP} of the damage`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.CALM_MIND]: {
+    eng: `Heal for 60% ${Stat.HP} of the damage`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.SWIFT_SWIM]: {
+    eng: `35% chance to burn 20 ${Stat.MANA} and return 15 ${Stat.MANA} to the attacker`,
+    esp: ``,
+    fra: `?NONE?`
+  },
+  [Effect.HYDRATION]: {
+    eng: `45% chance to burn 20 ${Stat.MANA} and return 30 ${Stat.MANA} to the attacker`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.WATER_VEIL]: {
+    eng: `55% chance to burn 20 ${Stat.MANA} and return 45 ${Stat.MANA} to the attacker`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.INFESTATION]: {
+    eng: `Copy 1 bug pokemon`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.HORDE]: {
+    eng: `Copy 2 bug pokemons`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.HEART_OF_THE_SWARM]: {
+    eng: `Copy 4 bug pokemons`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.TAILWIND]: {
+    eng: `Give ${Status.PROTECT} for 1 sec when under 20% ${Stat.HP}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.FEATHER_DANCE]: {
+    eng: `Give ${Status.PROTECT} for 1.5 sec when under 40% ${Stat.HP}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.MAX_AIRSTREAM]: {
+    eng: `Give ${Status.PROTECT} for 2 sec when under 50% ${Stat.HP}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.MAX_GUARD]: {
+    eng: `Give ${Status.PROTECT} for 2.5sec when under 50% ${Stat.HP}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.ODD_FLOWER]: {
+    eng: `Summon Oddish`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.GLOOM_FLOWER]: {
+    eng: `Summon Gloom`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.VILE_FLOWER]: {
+    eng: `Summon Vileplume`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.SUN_FLOWER]: {
+    eng: `Summon Belossom`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.BATTLE_ARMOR]: {
+    eng: `Gain 50 ${Stat.SHIELD}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.MOUTAIN_RESISTANCE]: {
+    eng: `Gain 100 ${Stat.SHIELD}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.DIAMOND_STORM]: {
+    eng: `Gain 200 ${Stat.SHIELD}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.PHANTOM_FORCE]: {
+    eng: `Deal 20% of ${Stat.ATK} as ${Damage.TRUE}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.CURSE]: {
+    eng: `Deal 40% of ${Stat.ATK} as ${Damage.TRUE}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.SHADOW_TAG]: {
+    eng: `Deal 70% of ${Stat.ATK} as ${Damage.TRUE}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.WANDERING_SPIRIT]: {
+    eng: `Deal 100% of ${Stat.ATK} as ${Damage.TRUE}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.AROMATIC_MIST]: {
+    eng: `Shocks deal 10 ${Damage.SPECIAL}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.FAIRY_WIND]: {
+    eng: `Shocks deal 30 ${Damage.SPECIAL}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.STRANGE_STEAM]: {
+    eng: `Shocks deal 60 ${Damage.SPECIAL}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.SNOW]: {
+    eng: `10% chance to ${Status.FREEZE} (Weather: Snow)`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.SHEER_COLD]: {
+    eng: `30% chance to ${Status.FREEZE} (Weather: Snow)`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.ANCIENT_POWER]: {
+    eng: `Revive with 40% ${Stat.HP} and +30% ${Stat.ATK}`,
+    esp: ``,
+    fra: ``
+  },
+  [Effect.ELDER_POWER]: {
+    eng: `Revive with 80% ${Stat.HP} and +60% ${Stat.ATK}.`,
     esp: ``,
     fra: ``
   },
   [Effect.LARGO]: {
-    eng: `+3 ${Stat.ATK} each time a sound pokemon use its ability`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+    eng: `Gain +3 ${Stat.ATK}`,
+    esp: ``,
+    fra: ``
   },
   [Effect.ALLEGRO]: {
-    eng: `+5 ${Stat.ATK} each time a sound pokemon use its ability`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+    eng: `Gain +5 ${Stat.ATK}`,
+    esp: ``,
+    fra: ``
   },
   [Effect.PRESTO]: {
-    eng: `+7 ${Stat.ATK} each time a sound pokemon use its ability`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+    eng: `Gain +7 ${Stat.ATK}`,
+    esp: ``,
+    fra: ``
   },
-  [Effect.SWIFT_SWIM]: {
-    eng: `Aquatic pokemons have a 35% chance to burn 20 ${Stat.MANA} from their target and return 15 ${Stat.MANA} to the attacker`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+  [Effect.DUBIOUS_DISC]: {
+    eng: `Gain +4 ${Stat.ATK} and +20 ${Stat.SHIELD} per held item`,
+    esp: ``,
+    fra: ``
   },
-  [Effect.HYDRATION]: {
-    eng: `Aquatic pokemons have a 45% chance to burn 20 ${Stat.MANA} from their target and return 30 ${Stat.MANA} to the attacker`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+  [Effect.LINK_CABLE]: {
+    eng: `Gain +7 ${Stat.ATK} and +30 ${Stat.SHIELD} per held item`,
+    esp: ``,
+    fra: ``
   },
-  [Effect.WATER_VEIL]: {
-    eng: `Aquatic pokemons have a 55% chance to burn 20 ${Stat.MANA} from their target and return 45 ${Stat.MANA} to the attacker`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+  [Effect.GOOGLE_SPECS]: {
+    eng: `Gain +10 ${Stat.ATK} and +50 ${Stat.SHIELD} per held item`,
+    esp: ``,
+    fra: ``
   },
   [Effect.HATCHER]: {
-    eng: `20% chance per consecutive defeat to find a Pokemon Egg after each stage`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+    eng: `20% chance per consecutive defeat to get an Egg`,
+    esp: ``,
+    fra: ``
   },
   [Effect.BREEDER]: {
-    eng: `Get a Pokemon Egg after each defeat against a player`,
-    esp: `?NONE?`,
-    fra: `?NONE?`
+    eng: `Get an Egg after each defeat against a player`,
+    esp: ``,
+    fra: ``
   }
 }

--- a/app/types/strings/Synergy.ts
+++ b/app/types/strings/Synergy.ts
@@ -1,5 +1,7 @@
 import { Effect } from "../enum/Effect"
+import { Damage, Stat } from "../enum/Game";
 import { Synergy } from "../enum/Synergy"
+import { Status } from "../enum/Status"
 
 export const SynergyName: {
   [key in Synergy]: { eng: string; esp: string; fra: string }
@@ -25,7 +27,7 @@ export const SynergyName: {
     fra: "Eau"
   },
   [Synergy.ELECTRIC]: {
-    eng: "Elec",
+    eng: "Electric",
     esp: "Elec",
     fra: "Elec"
   },
@@ -136,6 +138,146 @@ export const SynergyName: {
   },
   [Synergy.BABY]: {
     eng: "Baby",
+    esp: "",
+    fra: ""
+  }
+}
+
+export const SynergyDescription: {
+  [key in Synergy]: { eng: string; esp: string; fra: string }
+} = {
+  [Synergy.NORMAL]: {
+    eng: `Normal pokemons and their adjacent allies gain ${Stat.SHIELD} when combat starts`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.GRASS]: {
+    eng: `Grass pokemons heal over time`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.FIRE]: {
+    eng: `Fire pokemons gain ${Stat.ATK} after every hit and have a chance to ${Status.BURN} their enemies for 2 seconds`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.WATER]: {
+    eng: `Water pokemons have a chance to dodge basic attacks`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.ELECTRIC]: {
+    eng: `Electric pokemons basic attacks have a chance to trigger two additional attacks`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.FIGHTING]: {
+    eng: "Fighting pokemons block a flat amount of damage on every hit received",
+    esp: "",
+    fra: ""
+  },
+  [Synergy.PSYCHIC]: {
+    eng: `Psychic pokemons gain additional ${Stat.AP}`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.DARK]: {
+    eng: `Dark pokemons critical hits are more powerful and more frequent. Melee Dark pokemons jump to the farthest target reachable.`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.STEEL]: {
+    eng: `Steel pokemons can double their base ${Stat.ATK}`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.GROUND]: {
+    eng: `Ground pokemons gain bonus ${Stat.ATK}, ${Stat.DEF} and ${Stat.SPE_DEF} every 3 seconds, up to 4 times.`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.POISON]: {
+    eng: `Poison pokemons have a chance to ${Status.POISON} their target for seconds with their basic attacks `,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.DRAGON]: {
+    eng: `Dragon pokemons gain ${Stat.ATK_SPEED} after every basic attack`,
+    esp: "Dragón",
+    fra: "Dragon"
+  },
+  [Synergy.FIELD]: {
+    eng: `When a field pokemon dies, all the other field pokemons gain ${Stat.ATK_SPEED} and are healed for a percentage of their max ${Stat.HP}`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.MONSTER]: {
+    eng: `Monster pokemons heal and gain bonus stats every time they kill an enemy`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.HUMAN]: {
+    eng: `All your team heals for a percentage of the damage they deal with attacks and abilities`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.AQUATIC]: {
+    eng: `Aquatic pokemons have a chance to steal ${Stat.MANA} from their target at every basic attack`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.BUG]: {
+    eng: `At the start of the combat, the bug pokemons with the most ${Stat.HP} are duplicated`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.FLYING]: {
+    eng: `Flying pokemons get ${Status.PROTECT} when they fell under a certain amount of ${Stat.HP}`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.FLORA]: {
+    eng: "When the first flora pokemon is dead, a flower will rise from its grave...",
+    esp: "",
+    fra: ""
+  },
+  [Synergy.ROCK]: {
+    eng: `Rock pokemons gain ${Stat.SHIELD} at the start of the combat`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.GHOST]: {
+    eng: `Ghost pokemons have 50% chance to ${Status.SILENCE} on hit, and deal a percentage of their damage as ${Damage.TRUE}`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.FAIRY]: {
+    eng: "Fairy pokemons shock nearby enemies whenever they deal or receive a critical strike",
+    esp: "",
+    fra: ""
+  },
+  [Synergy.ICE]: {
+    eng: `All allies have a chance to ${Status.FREEZE} the enemy for 2 seconds after a hit`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.FOSSIL]: {
+    eng: `On their first death, fossil pokemons come back to life with increased ${Stat.ATK}`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.SOUND]: {
+    eng: `Sound pokemons gain ${Stat.ATK} every time they use their abilities`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.ARTIFICIAL]: {
+    eng: `Artificial pokemons gains ${Stat.ATK} and ${Stat.SHIELD} depending on the number of items held`,
+    esp: "",
+    fra: ""
+  },
+  [Synergy.BABY]: {
+    eng: `Babies can bring you Pokemon Eggs to comfort you after a defeat`,
     esp: "",
     fra: ""
   }


### PR DESCRIPTION
Add generic descriptions for synergies to simplify the effects descriptions

![image](https://user-images.githubusercontent.com/566536/233754347-05e8b96e-7e4e-4653-9bd9-6345a9f749fd.png)

also changed Dark pokemons jump mechanic as discussed here: https://discord.com/channels/737230355039387749/1099023190388375593