### PR TITLE
increase reconnection time in game

### DIFF
--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -397,8 +397,8 @@ export default class GameRoom extends Room<GameState> {
         throw new Error("consented leave")
       }
 
-      // allow disconnected client to reconnect into this room until 60 seconds
-      await this.allowReconnection(client, 60)
+      // allow disconnected client to reconnect into this room until 300 seconds
+      await this.allowReconnection(client, 300)
     } catch (e) {
       if (client && client.auth && client.auth.displayName) {
         console.log(`${client.auth.displayName} leave game room`)

--- a/app/rooms/preparation-room.ts
+++ b/app/rooms/preparation-room.ts
@@ -212,7 +212,7 @@ export default class PreparationRoom extends Room {
         throw new Error("consented leave")
       }
 
-      // allow disconnected client to reconnect into this room until 20 seconds
+      // allow disconnected client to reconnect into this room until 2 seconds
       await this.allowReconnection(client, 2)
     } catch (e) {
       if (client && client.auth && client.auth.displayName) {


### PR DESCRIPTION
Looks like server is a bit unstable at the moment. When websocket connections are lost, it's hard to figure out ingame, especially if you are not doing any actions, waiting for the next stage. Then the time you refresh the page to try to force reconnect, the expiration delay allowed for reconnection is over and you get "session expired" error.

I propose to update it from 1 minute to 5 minutes. I'm not sure why a  timeout is needed, if we don't have any reason we could also just allow any reconnection time by not providing a timeout parameter for game room.