### PR TITLE
nerf relic song

### DIFF
--- a/app/core/attack-strategy.ts
+++ b/app/core/attack-strategy.ts
@@ -1194,7 +1194,7 @@ export class RelicSongStrategy extends AttackStrategy {
     target: PokemonEntity
   ) {
     super.process(pokemon, state, board, target)
-    let duration = Math.round(3000 * (1 + pokemon.ap / 100))
+    let duration = Math.round(2000 * (1 + pokemon.ap / 200))
     board.forEach((x: number, y: number, tg: PokemonEntity | undefined) => {
       if (tg && pokemon.team != tg.team) {
         tg.status.triggerSleep(duration, tg)

--- a/app/core/pokemon-state.ts
+++ b/app/core/pokemon-state.ts
@@ -242,7 +242,7 @@ export default class PokemonState {
           }
 
           if (pokemon.status.sleep) {
-            pokemon.status.updateSleep(100)
+            pokemon.status.updateSleep(500)
           }
 
           if (pokemon.life && pokemon.life > 0) {

--- a/app/types/strings/Ability.ts
+++ b/app/types/strings/Ability.ts
@@ -878,7 +878,7 @@ export const AbilityDescription: { [key in Ability]: Langage } = {
     prt: ``
   },
   [Ability.RELIC_SONG]: {
-    eng: `Put ${Status.SLEEP} the whole enemy team for [3,SP] seconds`,
+    eng: `Put ${Status.SLEEP} the whole enemy team for [2,SP=0.5] seconds`,
     esp: ``,
     fra: ``,
     prt: ``

--- a/changelog/patch-3.4.md
+++ b/changelog/patch-3.4.md
@@ -4,6 +4,7 @@
 # Changes to Pokemon
 - Rework Abra: reduce attack cooldown after teleport ; now deals special damage after teleport instead of buffing attack
 - Nerf Virizion: max mana 90 → 120
+- Nerf Meloetta Relic Song: Base duration reduced from 3 seconds to 2 seconds, AP scaling reduced by 50%
 
 # Changes to Synergies
 
@@ -20,10 +21,12 @@
 - improvements to custom bot selector
 
 # Bugfix
+- fix a bug where power lens reflects the damage of another power lens, causing an infinite loop
 - fix redirection to homepage when attempting to reconnect to a game that does not exist
 - fix abilities with effects in line not hitting original target on some specific angles
 
 # Misc
 - add Kecleon and Arceus to Bot Builder
+- Sleep duration is now reduced by 500ms when taking hits (previously 100ms)
 
 


### PR DESCRIPTION
Nerf Meloetta Relic Song: Base duration reduced from 3 seconds to 2 seconds, AP scaling reduced by 50%
Sleep duration is now reduced by 500ms when taking hits (previously 100ms)

https://discord.com/channels/737230355039387749/1090058825945595954

players have been asking for a rework but lets try to balance it before changing Meloetta identity ?