### PR TITLE
add new level titles and bot builder title

### DIFF
--- a/app/public/src/game/components/item-detail.css
+++ b/app/public/src/game/components/item-detail.css
@@ -53,6 +53,7 @@
     padding: 0.25em 0.5em;
     margin: 0 -5px 4px -5px;
     font-size: 80%;
+    z-index: 2;
 }
 
 .game-item-detail-description:last-child {

--- a/app/public/src/pages/component/lobby-menu/profile.tsx
+++ b/app/public/src/pages/component/lobby-menu/profile.tsx
@@ -133,20 +133,20 @@ export default function Profile() {
           <TabPanel>
             <ul className="titles" style={{ display: "flex", flexDirection: "column", padding: 0 }}>
               {Object.keys(Title).map((k,i) => (
-                <li key={k} style={{ 
-                  padding: "0.5em",
-                  listStyle: "none",
-                  backgroundColor: i%2 ? '#54596b' : '#61738a'
-                }}>
-                  <h5
+                <li key={k} 
+                    style={{ 
+                      padding: "0.5em",
+                      listStyle: "none",
+                      backgroundColor: i%2 ? '#54596b' : '#61738a'
+                    }}
+                    className="clickable"
                     onClick={() => {
                       if (user.titles.includes(k as Title)) {
                         dispatch(setTitle(k))
                       }
                     }}
-                    style={{ color: user.title === k ? '#ffc107' : user.titles.includes(k as Title) ? "#92cc41" : "#db5e6a" }}
-                    className="clickable"
-                  >
+                >
+                  <h5 style={{ color: user.title === k ? '#ffc107' : user.titles.includes(k as Title) ? "#92cc41" : "#db5e6a" }}>
                     {TitleName[k]}
                   </h5>
                   <p style={{ 

--- a/app/public/src/pages/component/wiki/wiki-faq.tsx
+++ b/app/public/src/pages/component/wiki/wiki-faq.tsx
@@ -104,9 +104,10 @@ export default class WikiFaq extends Component {
         </p>
         <h4 className="nes-text is-success">Can i create my own bot ?</h4>
         <p>
-          Sure. Go to the bot builder in the lobby and try to make your own bot.
-          If you submit your bot, it'll be send in the #bot-creation channel for
-          a review by the bot reviewer team.
+          Sure. You'll need to be at least level 10 to unlock the Bot Builder title.
+          Then choose this title and a "Bot Builder" button will appear in the header.
+          Read the instructions and submit your bot, it will be sent in the 
+          #bot-creation channel on Discord for a review by the bot reviewers team.
         </p>
         <h4 className="nes-text is-success">How does the elo system work ?</h4>
         <p>

--- a/app/public/src/pages/lobby.tsx
+++ b/app/public/src/pages/lobby.tsx
@@ -49,7 +49,7 @@ import {
   setBotLeaderboard,
   setLeaderboard
 } from "../stores/LobbyStore"
-import { ICustomLobbyState, ISuggestionUser, Transfer } from "../../../types"
+import { ICustomLobbyState, ISuggestionUser, Title, Transfer } from "../../../types"
 import LobbyUser from "../../../models/colyseus-models/lobby-user"
 import { IBot } from "../../../models/mongo-models/bot-v2"
 import { IMeta } from "../../../models/mongo-models/meta"
@@ -324,7 +324,7 @@ export default function Lobby() {
           >
             Wiki
           </button>
-          {user?.anonymous === false ?
+          {user?.anonymous === false && user?.title === Title.BOT_BUILDER && 
           <button
             disabled={user?.anonymous}
             className="bubbly green"
@@ -336,7 +336,7 @@ export default function Lobby() {
             }}
           >
             BOT Builder
-          </button>: null}
+          </button>}
 
           <button
             className="bubbly green"

--- a/app/rooms/game-room.ts
+++ b/app/rooms/game-room.ts
@@ -478,16 +478,43 @@ export default class GameRoom extends Room<GameState> {
               logger.error(err)
             } else {
               const expThreshold = 1000
-              if (usr.exp + exp >= expThreshold) {
+              let remainingExpToGain = exp
+              while(usr.exp + remainingExpToGain >= expThreshold) {
                 usr.level += 1
                 usr.booster += 1
-                usr.exp = usr.exp + exp - expThreshold
-              } else {
-                usr.exp = usr.exp + exp
+                remainingExpToGain -= (expThreshold - usr.exp)
+                usr.exp = 0
               }
-              usr.exp = !isNaN(usr.exp) ? usr.exp : 0
+              usr.exp = remainingExpToGain > 0 ? remainingExpToGain : 0
+
               if (rank == 1) {
                 usr.wins += 1
+              }
+
+              if (usr.level >= 10) {
+                player.titles.add(Title.ROOKIE)
+                player.titles.add(Title.BOT_BUILDER)
+              }
+              if (usr.level >= 20) {
+                player.titles.add(Title.AMATEUR)
+              }
+              if (usr.level >= 30) {
+                player.titles.add(Title.VETERAN)
+              }
+              if (usr.level >= 50) {
+                player.titles.add(Title.PRO)
+              }
+              if (usr.level >= 100) {
+                player.titles.add(Title.EXPERT)
+              }
+              if (usr.level >= 150) {
+                player.titles.add(Title.ELITE)
+              }
+              if (usr.level >= 200) {
+                player.titles.add(Title.MASTER)
+              }
+              if (usr.level >= 300) {
+                player.titles.add(Title.GRAND_MASTER)
               }
 
               if (usr.elo) {
@@ -516,29 +543,29 @@ export default class GameRoom extends Room<GameState> {
                     elo: elo
                   })
                 }
-
-                if (player.life === 100 && rank === 1) {
-                  player.titles.add(Title.TYRANT)
-                }
-
-                if (player.rerollCount > 60) {
-                  player.titles.add(Title.GAMBLER)
-                }
-
-                if (usr.titles === undefined) {
-                  usr.titles = []
-                }
-
-                player.titles.forEach((t) => {
-                  if (!usr.titles.includes(t)) {
-                    logger.log("title added ", t)
-                    usr.titles.push(t)
-                  }
-                })
-                //logger.log(usr);
-                //usr.markModified('metadata');
-                usr.save()
               }
+
+              if (player.life === 100 && rank === 1) {
+                player.titles.add(Title.TYRANT)
+              }
+
+              if (player.rerollCount > 60) {
+                player.titles.add(Title.GAMBLER)
+              }                
+
+              if (usr.titles === undefined) {
+                usr.titles = []
+              }
+
+              player.titles.forEach((t) => {
+                if (!usr.titles.includes(t)) {
+                  logger.log("title added ", t)
+                  usr.titles.push(t)
+                }
+              })
+              //logger.log(usr);
+              //usr.markModified('metadata');
+              usr.save()
             }
           })
         }

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -504,6 +504,14 @@ export interface ISuggestionUser {
 
 export enum Title {
   NOVICE = "NOVICE",
+  ROOKIE = "ROOKIE",
+  AMATEUR = "AMATEUR",
+  VETERAN = "VETERAN",
+  PRO = "PRO",
+  EXPERT = "EXPERT",
+  ELITE = "ELITE",
+  MASTER = "MASTER",
+  GRAND_MASTER = "GRAND_MASTER",
   BIRD_KEEPER = "BIRD_KEEPER",
   BLACK_BELT = "BLACK_BELT",
   BUG_MANIAC = "BUG_MANIAC",
@@ -546,12 +554,21 @@ export enum Title {
   BACKER = "BACKER",
   TYRANT = "TYRANT",
   GAMBLER = "GAMBLER",
+  BOT_BUILDER = "BOT_BUILDER",
   SHINY_SEEKER = "SHINY_SEEKER",
   ARCHEOLOGIST = "ARCHEOLOGIST"
 }
 
 export const TitleName: { [key in Title]: string } = {
   [Title.NOVICE]: "Novice",
+  [Title.ROOKIE]: "Rookie",
+  [Title.AMATEUR]: "Amateur",
+  [Title.VETERAN]: "Veteran",
+  [Title.PRO]: "Pro",
+  [Title.EXPERT]: "Expert",
+  [Title.ELITE]: "Elite",
+  [Title.MASTER]: "Master",
+  [Title.GRAND_MASTER]: "Grand Master",
   [Title.BIRD_KEEPER]: "Bird Keeper",
   [Title.BLACK_BELT]: "Black Belt",
   [Title.BUG_MANIAC]: "Bug Maniac",
@@ -594,12 +611,21 @@ export const TitleName: { [key in Title]: string } = {
   [Title.BACKER]: "Backer",
   [Title.TYRANT]: "Tyrant",
   [Title.GAMBLER]: "Gambler",
+  [Title.BOT_BUILDER]: "Bot Builder",
   [Title.SHINY_SEEKER]: "Shiny Seeker",
   [Title.ARCHEOLOGIST]: "Archeologist"
 }
 
 export const TitleDescription: { [key in Title]: string } = {
   [Title.NOVICE]: "Play your first game",
+  [Title.ROOKIE]: "Reach level 10",
+  [Title.AMATEUR]: "Reach level 20",
+  [Title.VETERAN]: "Reach level 30",
+  [Title.PRO]: "Reach level 50",
+  [Title.EXPERT]: "Reach level 100",
+  [Title.ELITE]: "Reach level 150",
+  [Title.MASTER]: "Reach level 200",
+  [Title.GRAND_MASTER]: "Reach level 300",
   [Title.BIRD_KEEPER]: "Max Synergy With Flying type in a game",
   [Title.BLACK_BELT]: "Max Synergy With Fighting Type in a game",
   [Title.BUG_MANIAC]: "Max Synergy With Bug Type in a game",
@@ -642,6 +668,7 @@ export const TitleDescription: { [key in Title]: string } = {
   [Title.BACKER]: "Support the game financially",
   [Title.TYRANT]: "Win a game at 100 Hp",
   [Title.GAMBLER]: "Reroll over 60 times in a single match",
+  [Title.BOT_BUILDER]: "Reach level 10 to unlock the Bot Builder",
   [Title.SHINY_SEEKER]: "Have over 30 shiny pokemon avatars",
   [Title.ARCHEOLOGIST]: "Decipher the secret message of the Unowns"
 }

--- a/changelog/patch-3.5.md
+++ b/changelog/patch-3.5.md
@@ -35,4 +35,5 @@ Darkrai: New Dark void ability
 # Misc
 - Allow to buy a booster with 500 shards of a pokemon
 - Add How to play section to wiki with tutorial videos (thanks @Batotsu !)
-
+- Add 6 new titles based on reaching a certain level: Rookie, Amateur, Veteran, Pro, Expert, Elite, Master, Grand Master
+- Accessing the Bot Builder now requires the title "Bot Builder" which is unlocked at level 10

--- a/changelog/patch-3.5.md
+++ b/changelog/patch-3.5.md
@@ -35,5 +35,5 @@ Darkrai: New Dark void ability
 # Misc
 - Allow to buy a booster with 500 shards of a pokemon
 - Add How to play section to wiki with tutorial videos (thanks @Batotsu !)
-- Add 6 new titles based on reaching a certain level: Rookie, Amateur, Veteran, Pro, Expert, Elite, Master, Grand Master
+- Add 8 new titles based on reaching a certain level: Rookie, Amateur, Veteran, Pro, Expert, Elite, Master, Grand Master
 - Accessing the Bot Builder now requires the title "Bot Builder" which is unlocked at level 10


### PR DESCRIPTION
https://discord.com/channels/737230355039387749/1103679262747271290

- adds a Bot builder title unlocked at level 10. Title is required to access to Bot Builder
- adds 8 new ranks unlocked when reaching a certain level
- allows to earn several levels at once if you gain enough XP (should not change in practice but helpful for dev)
- minor UI bugfixes