### PR TITLE
Retrieve external assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ app/public/dist/client/index.js
 app/public/dist/client/index.js.map
 app/public/dist/client/index.css
 app/public/dist/client/index.css.map
+app/public/dist/client/assets/external/pokemonAutoChessMusic
+app/public/dist/client/assets/external/SpriteCollab
 app/public/dist/index.js
 *.code-workspace
 /app/public/dist/assets/tiles/newBackground.tmx

--- a/README.md
+++ b/README.md
@@ -12,10 +12,3 @@ Support: [https://en.tipeee.com/pokemon-auto-chess](https://en.tipeee.com/pokemo
 Discord: [https://discord.com/invite/6JMS7tr](https://discord.com/invite/6JMS7tr)
 
 Source: [https://github.com/keldaanInteractive/pokemonAutoChess](https://github.com/keldaanInteractive/pokemonAutoChess)
-
-## Dev setup
-
-```sh
-npm install
-npm run clone-external-assets
-```

--- a/README.md
+++ b/README.md
@@ -12,3 +12,10 @@ Support: [https://en.tipeee.com/pokemon-auto-chess](https://en.tipeee.com/pokemo
 Discord: [https://discord.com/invite/6JMS7tr](https://discord.com/invite/6JMS7tr)
 
 Source: [https://github.com/keldaanInteractive/pokemonAutoChess](https://github.com/keldaanInteractive/pokemonAutoChess)
+
+## Dev setup
+
+```sh
+npm install
+npm run clone-external-assets
+```

--- a/app/public/dist/client/assets/external/README.md
+++ b/app/public/dist/client/assets/external/README.md
@@ -1,0 +1,1 @@
+External assets are retrieved from Github by `install-external-assets` npm script

--- a/app/public/src/game/components/loading-manager.ts
+++ b/app/public/src/game/components/loading-manager.ts
@@ -44,7 +44,7 @@ export default class LoadingManager {
 
     if (scene.tilemap) {
       scene.load.audio("sound", [
-        `https://raw.githubusercontent.com/keldaanInteractive/pokemonAutoChessMusic/main/music/${scene.tilemap.tilesets[0].name}.mp3`
+        `assets/external/pokemonAutoChessMusic/music/${scene.tilemap.tilesets[0].name}.mp3`
       ])
       scene.load.image(
         "tiles",

--- a/app/public/src/pages/component/buttons/discord-button.tsx
+++ b/app/public/src/pages/component/buttons/discord-button.tsx
@@ -12,7 +12,7 @@ export default function DiscordButton() {
         handleDiscordClick()
       }}
     >
-      <img src="assets/ui/discord.svg" style={{ height: "100%" }} />
+      <img src="assets/ui/discord.svg" />
     </button>
   )
 }

--- a/app/public/src/pages/component/wiki/wiki-pokemon-detail.tsx
+++ b/app/public/src/pages/component/wiki/wiki-pokemon-detail.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react"
 import PokemonFactory from "../../../../../models/pokemon-factory"
-import { CDN_URL } from "../../../../../types"
+import { SPRITE_COLLAB_URL } from "../../../../../types"
 import { ICreditName } from "../../../../../types"
 import { AbilityName } from "../../../../../types/strings/Ability"
 import { ITracker } from "../../../../../types/ITracker"
@@ -23,7 +23,7 @@ export default function WikiPokemonDetail(props: {
   const [initialized, setInitialized] = useState<boolean>(false)
   if (!initialized) {
     setInitialized(true)
-    fetch(`${CDN_URL}/credit_names.txt`)
+    fetch(`${SPRITE_COLLAB_URL}/credit_names.txt`)
       .then((res) => res.text())
       .then((text) => text.split("\n"))
       .then((lines: string[]) =>

--- a/app/public/src/pages/component/wiki/wiki-tutorials.tsx
+++ b/app/public/src/pages/component/wiki/wiki-tutorials.tsx
@@ -17,6 +17,10 @@ export default class WikiTutorials extends Component {
           <iframe width="560" height="315" src="https://www.youtube.com/embed/LCU5oSyZagw" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen></iframe>
           <h3>Game Screen explained</h3>
         </li>
+        <li className="nes-container">
+          <iframe width="560" height="315" src="https://www.youtube.com/embed/UjV2TkGYIuM" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowFullScreen></iframe>
+          <h3>5 Tips for Pokemon AutoChess</h3>
+        </li>
       </ul>
       <p>Thanks to <a href="https://www.youtube.com/@batotsu2751" target="_blank">Batotsu</a> for his work on tutorial videos !</p>
       </div>

--- a/app/public/src/utils.ts
+++ b/app/public/src/utils.ts
@@ -1,4 +1,4 @@
-import { CDN_PORTRAIT_URL, Emotion } from "../../types"
+import { PORTRAITS_PATH, Emotion } from "../../types"
 
 export function getPortraitSrc(
   index: string,
@@ -7,14 +7,14 @@ export function getPortraitSrc(
 ) {
   const shinyPad = shiny ? (index.length === 4 ? "/0000/0001" : "/0001") : ""
   const emotionWithFallback = emotion ? emotion : Emotion.NORMAL
-  return `${CDN_PORTRAIT_URL}${index.replace(
+  return `${PORTRAITS_PATH}${index.replace(
     "-",
     "/"
   )}${shinyPad}/${emotionWithFallback}.png`
 }
 
 export function getAvatarSrc(avatar: string) {
-  return `${CDN_PORTRAIT_URL}${avatar.replace("-", "/")}.png`
+  return `${PORTRAITS_PATH}${avatar.replace("-", "/")}.png`
 }
 
 export function getInformations(avatar: string) {

--- a/app/rooms/custom-lobby-room.ts
+++ b/app/rooms/custom-lobby-room.ts
@@ -30,7 +30,7 @@ import {
   ISuggestionUser,
   Title,
   Role,
-  CDN_PORTRAIT_URL,
+  PORTRAITS_PATH,
   PrecomputedRaritPokemonyAll,
   USERNAME_REGEXP
 } from "../types"
@@ -704,7 +704,7 @@ export default class CustomLobbyRoom extends LobbyRoom {
                 message.shiny,
                 message.emotion
               )
-                .replace(CDN_PORTRAIT_URL, "")
+                .replace(PORTRAITS_PATH, "")
                 .replace(".png", "")
               user.avatar = portrait
               UserMetadata.findOne(

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -36,11 +36,9 @@ export * from "./enum/Emotion"
 
 export const FIGHTING_PHASE_DURATION = 40000
 
-export const CDN_PORTRAIT_URL =
-  "https://raw.githubusercontent.com/keldaanInteractive/SpriteCollab/master/portrait/"
+export const PORTRAITS_PATH = "assets/external/SpriteCollab/portrait/"
 
-export const CDN_URL =
-  "https://raw.githubusercontent.com/keldaanInteractive/SpriteCollab/master"
+export const SPRITE_COLLAB_URL = "https://raw.githubusercontent.com/keldaanInteractive/SpriteCollab/master"
 
 export const USERNAME_REGEXP =
   /^(?=.{4,20}$)(?:[\u0021-\uFFFF]+(?:(?:\.|-|_)[\u0021-\uFFFF])*)+$/

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,6 @@
         "npm-run-all": "^4.1.5",
         "openapi-typescript": "^5.3.0",
         "redux-devtools-extension": "^2.13.9",
-        "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^4.9.5"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "pokemon-autochess",
       "version": "3.4.0",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@colyseus/command": "^0.2.1",
@@ -71,6 +72,7 @@
         "npm-run-all": "^4.1.5",
         "openapi-typescript": "^5.3.0",
         "redux-devtools-extension": "^2.13.9",
+        "ts-node": "^10.9.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^4.9.5"
       },
@@ -12379,6 +12381,49 @@
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
       "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
+    "node_modules/ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ts-node-dev": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
@@ -12455,49 +12500,6 @@
       },
       "bin": {
         "rimraf": "bin.js"
-      }
-    },
-    "node_modules/ts-node-dev/node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
       }
     },
     "node_modules/tsconfig": {
@@ -22608,6 +22610,27 @@
       "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
       "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ=="
     },
+    "ts-node": {
+      "version": "10.9.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
+      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      }
+    },
     "ts-node-dev": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ts-node-dev/-/ts-node-dev-2.0.0.tgz",
@@ -22653,27 +22676,6 @@
           "dev": true,
           "requires": {
             "glob": "^7.1.3"
-          }
-        },
-        "ts-node": {
-          "version": "10.9.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-          "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-          "dev": true,
-          "requires": {
-            "@cspotcode/source-map-support": "^0.8.0",
-            "@tsconfig/node10": "^1.0.7",
-            "@tsconfig/node12": "^1.0.7",
-            "@tsconfig/node14": "^1.0.0",
-            "@tsconfig/node16": "^1.0.2",
-            "acorn": "^8.4.1",
-            "acorn-walk": "^8.1.1",
-            "arg": "^4.1.0",
-            "create-require": "^1.1.0",
-            "diff": "^4.0.1",
-            "make-error": "^1.1.1",
-            "v8-compile-cache-lib": "^3.0.1",
-            "yn": "3.1.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "npm-run-all": "^4.1.5",
     "openapi-typescript": "^5.3.0",
     "redux-devtools-extension": "^2.13.9",
-    "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "^4.9.5"
   }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,10 @@
   ],
   "main": "dist/server/index.js",
   "scripts": {
-    "reset": "rm -rf node_modules/ && rm -f app/public/js/*",    
-    "clone-external-assets": "cd app/public/dist/client/assets/external && git clone https://github.com/keldaanInteractive/pokemonAutoChessMusic.git && git clone https://github.com/keldaanInteractive/SpriteCollab.git",
+    "reset": "rm -rf node_modules/ && rm -f app/public/js/*",
+    "postinstall": "npm-run-all install-*",
+    "install-external-music": "cd app/public/dist/client/assets/external && git -C pokemonAutoChessMusic pull || git clone https://github.com/keldaanInteractive/pokemonAutoChessMusic.git",
+    "install-external-sprites": "cd app/public/dist/client/assets/external && git -C SpriteCollab pull || git clone https://github.com/keldaanInteractive/SpriteCollab.git",
     "dev-client": "node esbuild.js --dev",
     "dev-server": "ts-node-dev --watch \"src/**/*\" --respawn --transpile-only ./app/index.ts",
     "dev": "npm-run-all --parallel dev-*",
@@ -99,6 +101,7 @@
     "npm-run-all": "^4.1.5",
     "openapi-typescript": "^5.3.0",
     "redux-devtools-extension": "^2.13.9",
+    "ts-node": "^10.9.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "^4.9.5"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   ],
   "main": "dist/server/index.js",
   "scripts": {
-    "reset": "rm -rf node_modules/ && rm -f app/public/js/*",
+    "reset": "rm -rf node_modules/ && rm -f app/public/js/*",    
+    "clone-external-assets": "cd app/public/dist/client/assets/external && git clone https://github.com/keldaanInteractive/pokemonAutoChessMusic.git && git clone https://github.com/keldaanInteractive/SpriteCollab.git",
     "dev-client": "node esbuild.js --dev",
     "dev-server": "ts-node-dev --watch \"src/**/*\" --respawn --transpile-only ./app/index.ts",
     "dev": "npm-run-all --parallel dev-*",


### PR DESCRIPTION
move external assets from github to local folder to improve loading times

external assets are automatically cloned on local folder after npm install, so this should work for both development and production environment

☢TO BE CHECKED ON PROD 
- do we have enough disk space for music & sprites on prod ?
- does the deployment triggers postinstall script ?
- does the production environment has git installed ?