### PR TITLE
Allow to refill empty slots of the shop when locked

### DIFF
--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -100,12 +100,13 @@ export default class Shop {
     player.shop.forEach((pkm) => this.releasePokemon(pkm))
 
     for (let i = 0; i < 6; i++) {
-      let pokemon = this.pickPokemon(player)
       const seed = Math.random()
       if (seed < DITTO_RATE) {
-        pokemon = Pkm.DITTO
+        player.shop[i] = Pkm.DITTO
+      } else {
+        let pokemon = this.pickPokemon(player)
+        player.shop[i] = pokemon
       }
-      player.shop[i] = pokemon
     }
   }
 

--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -98,8 +98,8 @@ export default class Shop {
 
   refillShop(player: Player) {
     // No need to release pokemons since they won't be changed
-    player.shop = player.shop.map(pokemon =>{
-      if(pokemon != Pkm.MAGIKARP){
+    player.shop = player.shop.map((pokemon) =>{
+      if(pokemon != Pkm.MAGIKARP && pokemon != Pkm.DEFAULT){
         return pokemon
       } 
       return this.pickPokemon(player)

--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -186,10 +186,15 @@ export default class Shop {
 
   pickPokemon(player: Player) {
     const playerProbality = Probability[player.experienceManager.level]
-    const seed = Math.random()
+    const ditto_seed = Math.random()
+    const rarity_seed = Math.random()
     let pokemon = Pkm.MAGIKARP
     let threshold = 0
     const finals = new Array<Pkm>()
+    
+    if (ditto_seed < DITTO_RATE) {
+      return Pkm.DITTO
+    }
 
     player.board.forEach((pokemon: Pokemon) => {
       if (pokemon.final) {
@@ -199,7 +204,7 @@ export default class Shop {
 
     for (let i = 0; i < playerProbality.length; i++) {
       threshold += playerProbality[i]
-      if (seed < threshold) {
+      if (rarity_seed < threshold) {
         switch (i) {
           case 0:
             pokemon = this.getRandomPokemonFromPool(this.commonPool, finals)
@@ -218,17 +223,12 @@ export default class Shop {
             break
           default:
             logger.error(
-              `error in shop while picking seed = ${seed}, threshold = ${threshold}, index = ${i}`
+              `error in shop while picking seed = ${rarity_seed}, threshold = ${threshold}, index = ${i}`
             )
             break
         }
         break
       }
-    }
-
-    const ditto_seed = Math.random()
-    if (ditto_seed < DITTO_RATE) {
-      pokemon = Pkm.DITTO
     }
 
     return pokemon

--- a/app/models/shop.ts
+++ b/app/models/shop.ts
@@ -96,17 +96,21 @@ export default class Shop {
     }
   }
 
+  refillShop(player: Player) {
+    // No need to release pokemons since they won't be changed
+    player.shop = player.shop.map(pokemon =>{
+      if(pokemon != Pkm.MAGIKARP){
+        return pokemon
+      } 
+      return this.pickPokemon(player)
+    } )
+  }
+
   assignShop(player: Player) {
     player.shop.forEach((pkm) => this.releasePokemon(pkm))
 
     for (let i = 0; i < 6; i++) {
-      const seed = Math.random()
-      if (seed < DITTO_RATE) {
-        player.shop[i] = Pkm.DITTO
-      } else {
-        let pokemon = this.pickPokemon(player)
-        player.shop[i] = pokemon
-      }
+      player.shop[i] = this.pickPokemon(player)
     }
   }
 
@@ -221,6 +225,12 @@ export default class Shop {
         break
       }
     }
+
+    const ditto_seed = Math.random()
+    if (ditto_seed < DITTO_RATE) {
+      pokemon = Pkm.DITTO
+    }
+
     return pokemon
   }
 }

--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -1290,6 +1290,7 @@ export class OnUpdatePhaseCommand extends Command<GameRoom, any> {
           if (!player.shopLocked) {
             this.state.shop.assignShop(player)
           } else {
+            this.state.shop.refillShop(player)
             player.shopLocked = false
           }
         }


### PR DESCRIPTION
Allow the empty slots of the shop to be refreshed even when it is locked

I think that the lock could then stay locked for the next round, but since it is debatable I didn't changed it