### PR TITLE
fix(ditto): Prevents loss of object when duplication

### DIFF
--- a/app/rooms/commands/game-commands.ts
+++ b/app/rooms/commands/game-commands.ts
@@ -228,6 +228,9 @@ export class OnDragDropCommand extends Command<
               PokemonFactory.getPokemonBaseEvolution(pokemonToClone.name),
               player.pokemonCollection.get(PkmIndex[pokemonToClone.name])
             )
+            pokemon.items.forEach((it) => {
+              player.items.add(it)
+            })
             player.board.delete(detail.id)
             const position =
               this.room.getFirstAvailablePositionInBench(playerId)


### PR DESCRIPTION
This is a fast way to solve the problem

I think will try to create an "addItem" function on pokemons twhich will take the items and the player, wich will perform all the chevk necessary. 

This could make a common way to handle this case, the evolution case and the drop item all in one, since for now evolution only copies fused objects