### PR TITLE
fix(spectate): Allow spectating even when a 2+ stars portrait appears

### DIFF
--- a/app/public/src/pages/component/game/game-player.css
+++ b/app/public/src/pages/component/game/game-player.css
@@ -8,6 +8,7 @@
     border-radius: 50%;
     image-rendering: pixelated;
     box-shadow: inset 0 0 0 0.8vh black;
+    z-index: 2000;
 }
 
 .game-player .CircularProgressbar {


### PR DESCRIPTION
Upped the z-index of the game-players element in order to be over the toasts displayed when a 2+ starts pokemon is added on a player board (which then allow to click on them)